### PR TITLE
update concurrency variables

### DIFF
--- a/bhx_crawl.log
+++ b/bhx_crawl.log
@@ -7431,3 +7431,2318 @@ NotImplementedError
 2025-07-23 14:12:57 - INFO - Store 3786\uff5cFruit Jam: upserted 6, mod 0
 2025-07-23 14:12:58 - INFO - Store 3786\uff5cSnacks: upserted 12, mod 12
 2025-07-23 14:12:58 - INFO - \u2705 Total time: 372.16 minutes
+2025-07-23 14:28:07 - INFO - Store 3612\uff5cFresh Meat: upserted 8, mod 0
+2025-07-23 14:28:08 - INFO - Store 3612\uff5cFresh Meat: upserted 2, mod 0
+2025-07-23 14:28:11 - INFO - Store 3612\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 14:28:13 - INFO - Store 3612\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 14:28:14 - INFO - Store 3612\uff5cFresh Meat: upserted 12, mod 0
+2025-07-23 14:28:18 - INFO - Store 3612\uff5cSeafood & Fish Balls: upserted 12, mod 36
+2025-07-23 14:28:22 - INFO - Store 3612\uff5cFresh Fruits: upserted 12, mod 36
+2025-07-23 14:28:25 - INFO - Store 3612\uff5cVegetables: upserted 12, mod 12
+2025-07-23 14:28:29 - INFO - Store 3612\uff5cVegetables: upserted 12, mod 36
+2025-07-23 14:28:31 - INFO - Store 3612\uff5cVegetables: upserted 12, mod 12
+2025-07-23 14:28:34 - INFO - Store 3612\uff5cVegetables: upserted 12, mod 24
+2025-07-23 14:28:37 - INFO - Store 3612\uff5cAlcoholic Beverages: upserted 12, mod 24
+2025-07-23 14:28:49 - INFO - Store 3612\uff5cAlcoholic Beverages: upserted 12, mod 120
+2025-07-23 14:28:55 - INFO - Store 3612\uff5cBeverages: upserted 12, mod 36
+2025-07-23 14:29:08 - INFO - Store 3612\uff5cBeverages: upserted 12, mod 108
+2025-07-23 14:29:20 - INFO - Store 3612\uff5cBeverages: upserted 12, mod 96
+2025-07-23 14:29:25 - INFO - Store 3612\uff5cBeverages: upserted 12, mod 36
+2025-07-23 14:29:33 - INFO - Store 3612\uff5cBeverages: upserted 12, mod 60
+2025-07-23 14:29:38 - INFO - Store 3612\uff5cBeverages: upserted 12, mod 36
+2025-07-23 14:29:38 - INFO - Store 3612\uff5cBeverages: upserted 8, mod 0
+2025-07-23 14:29:47 - INFO - Store 3612\uff5cBeverages: upserted 12, mod 72
+2025-07-23 14:30:04 - INFO - Store 3612\uff5cBeverages: upserted 12, mod 132
+2025-07-23 14:30:04 - INFO - Store 3612\uff5cBeverages: upserted 9, mod 0
+2025-07-23 14:30:08 - INFO - Store 3612\uff5cMilk: upserted 12, mod 24
+2025-07-23 14:30:14 - INFO - Store 3612\uff5cMilk: upserted 12, mod 48
+2025-07-23 14:30:15 - INFO - Store 3612\uff5cMilk: upserted 12, mod 0
+2025-07-23 14:30:19 - INFO - Store 3612\uff5cMilk: upserted 12, mod 24
+2025-07-23 14:30:35 - INFO - Store 3612\uff5cMilk: upserted 12, mod 144
+2025-07-23 14:30:41 - INFO - Store 3612\uff5cMilk: upserted 12, mod 36
+2025-07-23 14:30:41 - INFO - Store 3612\uff5cMilk: upserted 4, mod 0
+2025-07-23 14:30:42 - INFO - Store 3612\uff5cSeasonings: upserted 1, mod 0
+2025-07-23 14:30:42 - INFO - Store 3612\uff5cSeasonings: upserted 3, mod 0
+2025-07-23 14:30:57 - INFO - Store 3612\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 14:31:03 - INFO - Store 3612\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 14:31:05 - INFO - Store 3612\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 14:31:08 - INFO - Store 3612\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 14:31:11 - INFO - Store 3612\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 14:31:17 - INFO - Store 3612\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 14:31:18 - INFO - Store 3612\uff5cSeasonings: upserted 8, mod 0
+2025-07-23 14:31:20 - INFO - Store 3612\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 14:31:25 - INFO - Store 3612\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 14:31:26 - INFO - Store 3612\uff5cSeasonings: upserted 4, mod 0
+2025-07-23 14:31:37 - INFO - Store 3612\uff5cSeasonings: upserted 12, mod 96
+2025-07-23 14:31:39 - INFO - Store 3612\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 14:31:43 - INFO - Store 3612\uff5cYogurt: upserted 12, mod 24
+2025-07-23 14:31:49 - INFO - Store 3612\uff5cYogurt: upserted 12, mod 60
+2025-07-23 14:31:54 - INFO - Store 3612\uff5cYogurt: upserted 12, mod 36
+2025-07-23 14:31:56 - INFO - Store 3612\uff5cCereals & Grains: upserted 12, mod 12
+2025-07-23 14:31:58 - INFO - Store 3612\uff5cCereals & Grains: upserted 11, mod 13
+2025-07-23 14:32:00 - INFO - Store 3612\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 14:32:00 - INFO - Store 3612\uff5cCold Cuts: Sausages & Ham: upserted 4, mod 0
+2025-07-23 14:32:01 - INFO - Store 3612\uff5cCold Cuts: Sausages & Ham: upserted 11, mod 0
+2025-07-23 14:32:02 - INFO - Store 3612\uff5cCold Cuts: Sausages & Ham: upserted 10, mod 0
+2025-07-23 14:32:04 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:32:08 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 14:32:10 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:32:14 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 14:32:15 - INFO - Store 3612\uff5cInstant Foods: upserted 3, mod 0
+2025-07-23 14:32:16 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:32:18 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:32:19 - INFO - Store 3612\uff5cInstant Foods: upserted 10, mod 0
+2025-07-23 14:32:24 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 14:32:26 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:32:27 - INFO - Store 3612\uff5cInstant Foods: upserted 10, mod 14
+2025-07-23 14:32:28 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 0
+2025-07-23 14:32:29 - INFO - Store 3612\uff5cInstant Foods: upserted 10, mod 0
+2025-07-23 14:32:30 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:32:31 - INFO - Store 3612\uff5cInstant Foods: upserted 4, mod 1
+2025-07-23 14:32:35 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 14:32:37 - INFO - Store 3612\uff5cInstant Foods: upserted 11, mod 13
+2025-07-23 14:32:39 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 14:32:41 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:32:42 - INFO - Store 3612\uff5cInstant Foods: upserted 2, mod 0
+2025-07-23 14:32:42 - INFO - Store 3612\uff5cInstant Foods: upserted 3, mod 1
+2025-07-23 14:32:42 - INFO - Store 3612\uff5cInstant Foods: upserted 6, mod 0
+2025-07-23 14:33:10 - INFO - Store 3612\uff5cInstant Foods: upserted 12, mod 324
+2025-07-23 14:33:13 - INFO - Store 3612\uff5cInstant Foods: upserted 2, mod 22
+2025-07-23 14:33:18 - INFO - Store 3612\uff5cGrains & Staples: upserted 12, mod 36
+2025-07-23 14:33:21 - INFO - Store 3612\uff5cGrains & Staples: upserted 12, mod 24
+2025-07-23 14:33:29 - INFO - Store 3612\uff5cCakes: upserted 12, mod 72
+2025-07-23 14:33:35 - INFO - Store 3612\uff5cCakes: upserted 12, mod 48
+2025-07-23 14:33:36 - INFO - Store 3612\uff5cCakes: upserted 12, mod 0
+2025-07-23 14:33:39 - INFO - Store 3612\uff5cCakes: upserted 12, mod 12
+2025-07-23 14:33:41 - INFO - Store 3612\uff5cCakes: upserted 12, mod 12
+2025-07-23 14:33:43 - INFO - Store 3612\uff5cCakes: upserted 12, mod 12
+2025-07-23 14:33:45 - INFO - Store 3612\uff5cCakes: upserted 12, mod 12
+2025-07-23 14:33:46 - INFO - Store 3612\uff5cCakes: upserted 3, mod 0
+2025-07-23 14:33:46 - INFO - Store 3612\uff5cCakes: upserted 4, mod 0
+2025-07-23 14:33:51 - INFO - Store 3612\uff5cCakes: upserted 12, mod 36
+2025-07-23 14:33:58 - INFO - Store 3612\uff5cCandies: upserted 12, mod 48
+2025-07-23 14:33:58 - INFO - Store 3612\uff5cCandies: upserted 10, mod 0
+2025-07-23 14:34:06 - INFO - Store 3612\uff5cCandies: upserted 12, mod 48
+2025-07-23 14:34:09 - INFO - Store 3612\uff5cDried Fruits: upserted 12, mod 24
+2025-07-23 14:34:11 - INFO - Store 3612\uff5cDried Fruits: upserted 12, mod 12
+2025-07-23 14:34:11 - INFO - Store 3612\uff5cFruit Jam: upserted 8, mod 0
+2025-07-23 14:34:13 - INFO - Store 3612\uff5cSnacks: upserted 12, mod 12
+2025-07-23 14:34:14 - INFO - Store 3712\uff5cFresh Meat: upserted 0, mod 7
+2025-07-23 14:34:15 - INFO - Store 3712\uff5cFresh Meat: upserted 0, mod 5
+2025-07-23 14:34:18 - INFO - Store 3712\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 14:34:22 - INFO - Store 3712\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 14:34:24 - INFO - Store 3712\uff5cFresh Meat: upserted 0, mod 24
+2025-07-23 14:34:30 - INFO - Store 3712\uff5cSeafood & Fish Balls: upserted 0, mod 60
+2025-07-23 14:34:34 - INFO - Store 3712\uff5cFresh Fruits: upserted 0, mod 48
+2025-07-23 14:34:37 - INFO - Store 3712\uff5cVegetables: upserted 0, mod 24
+2025-07-23 14:34:42 - INFO - Store 3712\uff5cVegetables: upserted 1, mod 59
+2025-07-23 14:34:45 - INFO - Store 3712\uff5cVegetables: upserted 0, mod 24
+2025-07-23 14:34:48 - INFO - Store 3712\uff5cVegetables: upserted 0, mod 36
+2025-07-23 14:34:53 - INFO - Store 3712\uff5cAlcoholic Beverages: upserted 0, mod 48
+2025-07-23 14:35:08 - INFO - Store 3712\uff5cAlcoholic Beverages: upserted 0, mod 144
+2025-07-23 14:35:13 - INFO - Store 3712\uff5cBeverages: upserted 1, mod 47
+2025-07-23 14:35:27 - INFO - Store 3712\uff5cBeverages: upserted 0, mod 132
+2025-07-23 14:35:38 - INFO - Store 3712\uff5cBeverages: upserted 0, mod 96
+2025-07-23 14:35:44 - INFO - Store 3712\uff5cBeverages: upserted 0, mod 48
+2025-07-23 14:35:51 - INFO - Store 3712\uff5cBeverages: upserted 0, mod 72
+2025-07-23 14:35:56 - INFO - Store 3712\uff5cBeverages: upserted 0, mod 48
+2025-07-23 14:35:57 - INFO - Store 3712\uff5cBeverages: upserted 0, mod 7
+2025-07-23 14:36:16 - INFO - Store 3712\uff5cBeverages: upserted 0, mod 96
+2025-07-23 14:36:34 - INFO - Store 3712\uff5cBeverages: upserted 0, mod 144
+2025-07-23 14:36:35 - INFO - Store 3712\uff5cBeverages: upserted 0, mod 12
+2025-07-23 14:36:39 - INFO - Store 3712\uff5cMilk: upserted 0, mod 36
+2025-07-23 14:36:46 - INFO - Store 3712\uff5cMilk: upserted 0, mod 60
+2025-07-23 14:36:48 - INFO - Store 3712\uff5cMilk: upserted 0, mod 24
+2025-07-23 14:36:54 - INFO - Store 3712\uff5cMilk: upserted 0, mod 48
+2025-07-23 14:37:12 - INFO - Store 3712\uff5cMilk: upserted 0, mod 168
+2025-07-23 14:37:17 - INFO - Store 3712\uff5cMilk: upserted 0, mod 48
+2025-07-23 14:37:18 - INFO - Store 3712\uff5cMilk: upserted 0, mod 11
+2025-07-23 14:37:19 - INFO - Store 3712\uff5cSeasonings: upserted 0, mod 1
+2025-07-23 14:37:19 - INFO - Store 3712\uff5cSeasonings: upserted 0, mod 3
+2025-07-23 14:37:23 - INFO - Store 3712\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 14:37:28 - INFO - Store 3712\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 14:37:32 - INFO - Store 3712\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 14:37:34 - INFO - Store 3712\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 14:37:39 - INFO - Store 3712\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 14:37:44 - INFO - Store 3712\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 14:37:45 - INFO - Store 3712\uff5cSeasonings: upserted 0, mod 9
+2025-07-23 14:37:48 - INFO - Store 3712\uff5cSeasonings: upserted 1, mod 23
+2025-07-23 14:37:53 - INFO - Store 3712\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 14:37:54 - INFO - Store 3712\uff5cSeasonings: upserted 0, mod 5
+2025-07-23 14:38:09 - INFO - Store 3712\uff5cSeasonings: upserted 0, mod 120
+2025-07-23 14:38:12 - INFO - Store 3712\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 14:38:17 - INFO - Store 3712\uff5cYogurt: upserted 1, mod 47
+2025-07-23 14:38:25 - INFO - Store 3712\uff5cYogurt: upserted 1, mod 71
+2025-07-23 14:38:33 - INFO - Store 3712\uff5cYogurt: upserted 1, mod 59
+2025-07-23 14:38:35 - INFO - Store 3712\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 14:38:37 - INFO - Store 3712\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 14:38:43 - INFO - Store 3712\uff5cCold Cuts: Sausages & Ham: upserted 1, mod 35
+2025-07-23 14:38:44 - INFO - Store 3712\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 6
+2025-07-23 14:38:47 - INFO - Store 3712\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 24
+2025-07-23 14:38:49 - INFO - Store 3712\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 24
+2025-07-23 14:38:51 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 14:39:04 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 60
+2025-07-23 14:39:08 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 14:39:16 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 14:39:17 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 7
+2025-07-23 14:39:19 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 14:39:24 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 14:39:42 - INFO - Store 3712\uff5cInstant Foods: upserted 2, mod 22
+2025-07-23 14:40:06 - INFO - Store 3712\uff5cInstant Foods: upserted 1, mod 59
+2025-07-23 14:40:45 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 14:40:56 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 14:41:02 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 14:41:03 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 9
+2025-07-23 14:41:05 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 14:41:06 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 11
+2025-07-23 14:41:13 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 14:41:17 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 14:41:22 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 36
+2025-07-23 14:41:31 - INFO - Store 3712\uff5cInstant Foods: upserted 1, mod 23
+2025-07-23 14:41:32 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 5
+2025-07-23 14:41:33 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 10
+2025-07-23 14:41:35 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 14:42:11 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 360
+2025-07-23 14:42:14 - INFO - Store 3712\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 14:42:21 - INFO - Store 3712\uff5cGrains & Staples: upserted 1, mod 59
+2025-07-23 14:42:24 - INFO - Store 3712\uff5cGrains & Staples: upserted 0, mod 36
+2025-07-23 14:42:42 - INFO - Store 3712\uff5cCakes: upserted 0, mod 96
+2025-07-23 14:42:51 - INFO - Store 3712\uff5cCakes: upserted 0, mod 48
+2025-07-23 14:42:53 - INFO - Store 3712\uff5cCakes: upserted 0, mod 11
+2025-07-23 14:43:03 - INFO - Store 3712\uff5cCakes: upserted 0, mod 24
+2025-07-23 14:43:13 - INFO - Store 3712\uff5cCakes: upserted 1, mod 23
+2025-07-23 14:43:16 - INFO - Store 3712\uff5cCakes: upserted 0, mod 24
+2025-07-23 14:43:20 - INFO - Store 3712\uff5cCakes: upserted 0, mod 24
+2025-07-23 14:43:21 - INFO - Store 3712\uff5cCakes: upserted 0, mod 4
+2025-07-23 14:43:21 - INFO - Store 3712\uff5cCakes: upserted 0, mod 6
+2025-07-23 14:43:46 - INFO - Store 3712\uff5cCakes: upserted 0, mod 36
+2025-07-23 14:44:04 - INFO - Store 3712\uff5cCandies: upserted 0, mod 60
+2025-07-23 14:44:07 - INFO - Store 3712\uff5cCandies: upserted 1, mod 23
+2025-07-23 14:44:14 - INFO - Store 3712\uff5cCandies: upserted 0, mod 72
+2025-07-23 14:44:19 - INFO - Store 3712\uff5cDried Fruits: upserted 0, mod 48
+2025-07-23 14:44:32 - INFO - Store 3712\uff5cDried Fruits: upserted 0, mod 24
+2025-07-23 14:44:33 - INFO - Store 3712\uff5cFruit Jam: upserted 0, mod 8
+2025-07-23 14:44:41 - INFO - Store 3712\uff5cSnacks: upserted 0, mod 24
+2025-07-23 14:44:42 - INFO - Store 2405\uff5cFresh Meat: upserted 6, mod 0
+2025-07-23 14:44:43 - INFO - Store 2405\uff5cFresh Meat: upserted 1, mod 0
+2025-07-23 14:44:47 - INFO - Store 2405\uff5cFresh Meat: upserted 10, mod 1
+2025-07-23 14:44:50 - INFO - Store 2405\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 14:44:58 - INFO - Store 2405\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 14:45:05 - INFO - Store 2405\uff5cSeafood & Fish Balls: upserted 12, mod 36
+2025-07-23 14:45:12 - INFO - Store 2405\uff5cFresh Fruits: upserted 12, mod 24
+2025-07-23 14:45:13 - INFO - Store 2405\uff5cVegetables: upserted 12, mod 0
+2025-07-23 14:45:18 - INFO - Store 2405\uff5cVegetables: upserted 12, mod 36
+2025-07-23 14:45:22 - INFO - Store 2405\uff5cVegetables: upserted 12, mod 12
+2025-07-23 14:45:31 - INFO - Store 2405\uff5cVegetables: upserted 12, mod 24
+2025-07-23 14:45:35 - INFO - Store 2405\uff5cAlcoholic Beverages: upserted 12, mod 36
+2025-07-23 14:45:47 - INFO - Store 2405\uff5cAlcoholic Beverages: upserted 12, mod 108
+2025-07-23 14:45:52 - INFO - Store 2405\uff5cBeverages: upserted 12, mod 36
+2025-07-23 14:46:08 - INFO - Store 2405\uff5cBeverages: upserted 12, mod 120
+2025-07-23 14:46:19 - INFO - Store 2405\uff5cBeverages: upserted 12, mod 84
+2025-07-23 14:46:25 - INFO - Store 2405\uff5cBeverages: upserted 12, mod 36
+2025-07-23 14:46:33 - INFO - Store 2405\uff5cBeverages: upserted 12, mod 60
+2025-07-23 14:46:38 - INFO - Store 2405\uff5cBeverages: upserted 12, mod 36
+2025-07-23 14:46:39 - INFO - Store 2405\uff5cBeverages: upserted 11, mod 0
+2025-07-23 14:46:48 - INFO - Store 2405\uff5cBeverages: upserted 12, mod 72
+2025-07-23 14:47:04 - INFO - Store 2405\uff5cBeverages: upserted 12, mod 132
+2025-07-23 14:47:05 - INFO - Store 2405\uff5cBeverages: upserted 12, mod 0
+2025-07-23 14:47:09 - INFO - Store 2405\uff5cMilk: upserted 12, mod 24
+2025-07-23 14:47:15 - INFO - Store 2405\uff5cMilk: upserted 12, mod 48
+2025-07-23 14:47:17 - INFO - Store 2405\uff5cMilk: upserted 12, mod 12
+2025-07-23 14:47:21 - INFO - Store 2405\uff5cMilk: upserted 12, mod 24
+2025-07-23 14:47:40 - INFO - Store 2405\uff5cMilk: upserted 12, mod 156
+2025-07-23 14:47:45 - INFO - Store 2405\uff5cMilk: upserted 12, mod 36
+2025-07-23 14:47:45 - INFO - Store 2405\uff5cMilk: upserted 5, mod 0
+2025-07-23 14:47:46 - INFO - Store 2405\uff5cSeasonings: upserted 1, mod 0
+2025-07-23 14:47:46 - INFO - Store 2405\uff5cSeasonings: upserted 3, mod 0
+2025-07-23 14:47:52 - INFO - Store 2405\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 14:47:57 - INFO - Store 2405\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 14:48:00 - INFO - Store 2405\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 14:48:02 - INFO - Store 2405\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 14:48:06 - INFO - Store 2405\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 14:48:12 - INFO - Store 2405\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 14:48:13 - INFO - Store 2405\uff5cSeasonings: upserted 10, mod 0
+2025-07-23 14:48:15 - INFO - Store 2405\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 14:48:21 - INFO - Store 2405\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 14:48:21 - INFO - Store 2405\uff5cSeasonings: upserted 5, mod 0
+2025-07-23 14:48:33 - INFO - Store 2405\uff5cSeasonings: upserted 12, mod 96
+2025-07-23 14:48:36 - INFO - Store 2405\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 14:48:39 - INFO - Store 2405\uff5cYogurt: upserted 12, mod 24
+2025-07-23 14:48:47 - INFO - Store 2405\uff5cYogurt: upserted 12, mod 72
+2025-07-23 14:48:51 - INFO - Store 2405\uff5cYogurt: upserted 12, mod 36
+2025-07-23 14:48:54 - INFO - Store 2405\uff5cCereals & Grains: upserted 12, mod 12
+2025-07-23 14:48:56 - INFO - Store 2405\uff5cCereals & Grains: upserted 11, mod 13
+2025-07-23 14:48:58 - INFO - Store 2405\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 14:48:59 - INFO - Store 2405\uff5cCold Cuts: Sausages & Ham: upserted 5, mod 0
+2025-07-23 14:49:01 - INFO - Store 2405\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 14:49:03 - INFO - Store 2405\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 14:49:05 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:49:10 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 14:49:12 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:49:16 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 14:49:16 - INFO - Store 2405\uff5cInstant Foods: upserted 4, mod 0
+2025-07-23 14:49:19 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:49:23 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 14:49:23 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 0
+2025-07-23 14:49:28 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 14:49:30 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:49:33 - INFO - Store 2405\uff5cInstant Foods: upserted 8, mod 16
+2025-07-23 14:49:35 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:49:35 - INFO - Store 2405\uff5cInstant Foods: upserted 8, mod 0
+2025-07-23 14:49:37 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:49:38 - INFO - Store 2405\uff5cInstant Foods: upserted 5, mod 2
+2025-07-23 14:49:42 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 14:49:44 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:49:47 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 14:49:49 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:49:50 - INFO - Store 2405\uff5cInstant Foods: upserted 2, mod 1
+2025-07-23 14:49:51 - INFO - Store 2405\uff5cInstant Foods: upserted 3, mod 2
+2025-07-23 14:49:51 - INFO - Store 2405\uff5cInstant Foods: upserted 7, mod 0
+2025-07-23 14:50:21 - INFO - Store 2405\uff5cInstant Foods: upserted 12, mod 324
+2025-07-23 14:50:24 - INFO - Store 2405\uff5cInstant Foods: upserted 2, mod 22
+2025-07-23 14:50:29 - INFO - Store 2405\uff5cGrains & Staples: upserted 12, mod 48
+2025-07-23 14:50:33 - INFO - Store 2405\uff5cGrains & Staples: upserted 12, mod 24
+2025-07-23 14:50:41 - INFO - Store 2405\uff5cCakes: upserted 12, mod 72
+2025-07-23 14:50:46 - INFO - Store 2405\uff5cCakes: upserted 12, mod 36
+2025-07-23 14:50:47 - INFO - Store 2405\uff5cCakes: upserted 11, mod 0
+2025-07-23 14:50:50 - INFO - Store 2405\uff5cCakes: upserted 12, mod 12
+2025-07-23 14:50:52 - INFO - Store 2405\uff5cCakes: upserted 12, mod 12
+2025-07-23 14:50:55 - INFO - Store 2405\uff5cCakes: upserted 12, mod 24
+2025-07-23 14:50:58 - INFO - Store 2405\uff5cCakes: upserted 12, mod 12
+2025-07-23 14:50:59 - INFO - Store 2405\uff5cCakes: upserted 4, mod 0
+2025-07-23 14:51:00 - INFO - Store 2405\uff5cCakes: upserted 7, mod 0
+2025-07-23 14:51:05 - INFO - Store 2405\uff5cCakes: upserted 12, mod 36
+2025-07-23 14:51:10 - INFO - Store 2405\uff5cCandies: upserted 12, mod 36
+2025-07-23 14:51:13 - INFO - Store 2405\uff5cCandies: upserted 12, mod 12
+2025-07-23 14:51:21 - INFO - Store 2405\uff5cCandies: upserted 12, mod 60
+2025-07-23 14:51:25 - INFO - Store 2405\uff5cDried Fruits: upserted 12, mod 24
+2025-07-23 14:51:28 - INFO - Store 2405\uff5cDried Fruits: upserted 12, mod 12
+2025-07-23 14:51:28 - INFO - Store 2405\uff5cFruit Jam: upserted 8, mod 0
+2025-07-23 14:51:30 - INFO - Store 2405\uff5cSnacks: upserted 12, mod 12
+2025-07-23 14:51:31 - INFO - Store 4244\uff5cFresh Meat: upserted 6, mod 0
+2025-07-23 14:51:32 - INFO - Store 4244\uff5cFresh Meat: upserted 5, mod 0
+2025-07-23 14:51:35 - INFO - Store 4244\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 14:51:37 - INFO - Store 4244\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 14:51:39 - INFO - Store 4244\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 14:51:44 - INFO - Store 4244\uff5cSeafood & Fish Balls: upserted 12, mod 36
+2025-07-23 14:51:47 - INFO - Store 4244\uff5cFresh Fruits: upserted 12, mod 24
+2025-07-23 14:51:49 - INFO - Store 4244\uff5cVegetables: upserted 12, mod 12
+2025-07-23 14:51:54 - INFO - Store 4244\uff5cVegetables: upserted 12, mod 36
+2025-07-23 14:51:57 - INFO - Store 4244\uff5cVegetables: upserted 12, mod 12
+2025-07-23 14:52:00 - INFO - Store 4244\uff5cVegetables: upserted 12, mod 24
+2025-07-23 14:52:05 - INFO - Store 4244\uff5cAlcoholic Beverages: upserted 12, mod 36
+2025-07-23 14:52:20 - INFO - Store 4244\uff5cAlcoholic Beverages: upserted 12, mod 144
+2025-07-23 14:52:27 - INFO - Store 4244\uff5cBeverages: upserted 12, mod 48
+2025-07-23 14:52:41 - INFO - Store 4244\uff5cBeverages: upserted 12, mod 120
+2025-07-23 14:52:52 - INFO - Store 4244\uff5cBeverages: upserted 12, mod 96
+2025-07-23 14:52:59 - INFO - Store 4244\uff5cBeverages: upserted 12, mod 48
+2025-07-23 14:53:07 - INFO - Store 4244\uff5cBeverages: upserted 12, mod 60
+2025-07-23 14:53:12 - INFO - Store 4244\uff5cBeverages: upserted 12, mod 36
+2025-07-23 14:53:15 - INFO - Store 4244\uff5cBeverages: upserted 12, mod 12
+2025-07-23 14:53:25 - INFO - Store 4244\uff5cBeverages: upserted 12, mod 84
+2025-07-23 14:53:41 - INFO - Store 4244\uff5cBeverages: upserted 12, mod 132
+2025-07-23 14:53:44 - INFO - Store 4244\uff5cBeverages: upserted 12, mod 12
+2025-07-23 14:53:48 - INFO - Store 4244\uff5cMilk: upserted 12, mod 24
+2025-07-23 14:53:54 - INFO - Store 4244\uff5cMilk: upserted 12, mod 48
+2025-07-23 14:54:01 - INFO - Store 4244\uff5cMilk: upserted 12, mod 12
+2025-07-23 14:54:08 - INFO - Store 4244\uff5cMilk: upserted 12, mod 36
+2025-07-23 14:54:26 - INFO - Store 4244\uff5cMilk: upserted 12, mod 156
+2025-07-23 14:54:31 - INFO - Store 4244\uff5cMilk: upserted 12, mod 36
+2025-07-23 14:54:32 - INFO - Store 4244\uff5cMilk: upserted 8, mod 0
+2025-07-23 14:54:32 - INFO - Store 4244\uff5cSeasonings: upserted 2, mod 0
+2025-07-23 14:54:33 - INFO - Store 4244\uff5cSeasonings: upserted 3, mod 0
+2025-07-23 14:54:36 - INFO - Store 4244\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 14:54:43 - INFO - Store 4244\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 14:54:45 - INFO - Store 4244\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 14:54:48 - INFO - Store 4244\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 14:54:51 - INFO - Store 4244\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 14:54:59 - INFO - Store 4244\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 14:55:00 - INFO - Store 4244\uff5cSeasonings: upserted 9, mod 0
+2025-07-23 14:55:02 - INFO - Store 4244\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 14:55:07 - INFO - Store 4244\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 14:55:08 - INFO - Store 4244\uff5cSeasonings: upserted 5, mod 0
+2025-07-23 14:55:22 - INFO - Store 4244\uff5cSeasonings: upserted 12, mod 108
+2025-07-23 14:55:26 - INFO - Store 4244\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 14:55:29 - INFO - Store 4244\uff5cYogurt: upserted 12, mod 24
+2025-07-23 14:55:36 - INFO - Store 4244\uff5cYogurt: upserted 12, mod 60
+2025-07-23 14:55:42 - INFO - Store 4244\uff5cYogurt: upserted 12, mod 48
+2025-07-23 14:55:44 - INFO - Store 4244\uff5cCereals & Grains: upserted 12, mod 12
+2025-07-23 14:55:46 - INFO - Store 4244\uff5cCereals & Grains: upserted 12, mod 12
+2025-07-23 14:55:56 - INFO - Store 4244\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 24
+2025-07-23 14:55:59 - INFO - Store 4244\uff5cCold Cuts: Sausages & Ham: upserted 7, mod 0
+2025-07-23 14:56:01 - INFO - Store 4244\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 14:56:03 - INFO - Store 4244\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 14:56:05 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:56:11 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 14:56:14 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:56:21 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 14:56:22 - INFO - Store 4244\uff5cInstant Foods: upserted 8, mod 0
+2025-07-23 14:56:24 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:56:26 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:56:29 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 14:56:36 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 14:56:38 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:56:39 - INFO - Store 4244\uff5cInstant Foods: upserted 6, mod 18
+2025-07-23 14:56:41 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:56:42 - INFO - Store 4244\uff5cInstant Foods: upserted 11, mod 0
+2025-07-23 14:56:44 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:56:44 - INFO - Store 4244\uff5cInstant Foods: upserted 10, mod 1
+2025-07-23 14:56:48 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 14:56:50 - INFO - Store 4244\uff5cInstant Foods: upserted 11, mod 13
+2025-07-23 14:56:54 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 14:56:55 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:56:56 - INFO - Store 4244\uff5cInstant Foods: upserted 7, mod 1
+2025-07-23 14:56:57 - INFO - Store 4244\uff5cInstant Foods: upserted 9, mod 1
+2025-07-23 14:56:59 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 14:57:31 - INFO - Store 4244\uff5cInstant Foods: upserted 12, mod 348
+2025-07-23 14:57:34 - INFO - Store 4244\uff5cInstant Foods: upserted 5, mod 19
+2025-07-23 14:57:40 - INFO - Store 4244\uff5cGrains & Staples: upserted 12, mod 48
+2025-07-23 14:57:43 - INFO - Store 4244\uff5cGrains & Staples: upserted 12, mod 24
+2025-07-23 14:57:54 - INFO - Store 4244\uff5cCakes: upserted 12, mod 96
+2025-07-23 14:57:59 - INFO - Store 4244\uff5cCakes: upserted 12, mod 36
+2025-07-23 14:58:02 - INFO - Store 4244\uff5cCakes: upserted 12, mod 12
+2025-07-23 14:58:05 - INFO - Store 4244\uff5cCakes: upserted 12, mod 12
+2025-07-23 14:58:08 - INFO - Store 4244\uff5cCakes: upserted 12, mod 12
+2025-07-23 14:58:10 - INFO - Store 4244\uff5cCakes: upserted 12, mod 12
+2025-07-23 14:58:13 - INFO - Store 4244\uff5cCakes: upserted 12, mod 24
+2025-07-23 14:58:14 - INFO - Store 4244\uff5cCakes: upserted 4, mod 0
+2025-07-23 14:58:15 - INFO - Store 4244\uff5cCakes: upserted 12, mod 0
+2025-07-23 14:58:20 - INFO - Store 4244\uff5cCakes: upserted 12, mod 36
+2025-07-23 14:58:25 - INFO - Store 4244\uff5cCandies: upserted 12, mod 48
+2025-07-23 14:58:28 - INFO - Store 4244\uff5cCandies: upserted 12, mod 12
+2025-07-23 14:58:35 - INFO - Store 4244\uff5cCandies: upserted 12, mod 60
+2025-07-23 14:58:39 - INFO - Store 4244\uff5cDried Fruits: upserted 12, mod 36
+2025-07-23 14:58:41 - INFO - Store 4244\uff5cDried Fruits: upserted 12, mod 12
+2025-07-23 14:58:42 - INFO - Store 4244\uff5cFruit Jam: upserted 7, mod 0
+2025-07-23 14:58:44 - INFO - Store 4244\uff5cSnacks: upserted 12, mod 12
+2025-07-23 14:58:45 - INFO - Store 2900\uff5cFresh Meat: upserted 9, mod 0
+2025-07-23 14:58:45 - INFO - Store 2900\uff5cFresh Meat: upserted 4, mod 0
+2025-07-23 14:58:48 - INFO - Store 2900\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 14:58:51 - INFO - Store 2900\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 14:58:51 - INFO - Store 2900\uff5cFresh Meat: upserted 10, mod 0
+2025-07-23 14:58:54 - INFO - Store 2900\uff5cSeafood & Fish Balls: upserted 12, mod 24
+2025-07-23 14:58:57 - INFO - Store 2900\uff5cFresh Fruits: upserted 12, mod 24
+2025-07-23 14:59:00 - INFO - Store 2900\uff5cVegetables: upserted 12, mod 12
+2025-07-23 14:59:04 - INFO - Store 2900\uff5cVegetables: upserted 12, mod 36
+2025-07-23 14:59:07 - INFO - Store 2900\uff5cVegetables: upserted 12, mod 12
+2025-07-23 14:59:10 - INFO - Store 2900\uff5cVegetables: upserted 12, mod 24
+2025-07-23 14:59:15 - INFO - Store 2900\uff5cAlcoholic Beverages: upserted 12, mod 36
+2025-07-23 14:59:28 - INFO - Store 2900\uff5cAlcoholic Beverages: upserted 12, mod 120
+2025-07-23 14:59:39 - INFO - Store 2900\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:00:06 - INFO - Store 2900\uff5cBeverages: upserted 12, mod 108
+2025-07-23 15:00:18 - INFO - Store 2900\uff5cBeverages: upserted 12, mod 96
+2025-07-23 15:00:24 - INFO - Store 2900\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:00:33 - INFO - Store 2900\uff5cBeverages: upserted 12, mod 60
+2025-07-23 15:00:38 - INFO - Store 2900\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:00:39 - INFO - Store 2900\uff5cBeverages: upserted 11, mod 0
+2025-07-23 15:00:47 - INFO - Store 2900\uff5cBeverages: upserted 12, mod 60
+2025-07-23 15:01:04 - INFO - Store 2900\uff5cBeverages: upserted 12, mod 132
+2025-07-23 15:01:07 - INFO - Store 2900\uff5cBeverages: upserted 12, mod 12
+2025-07-23 15:01:10 - INFO - Store 2900\uff5cMilk: upserted 12, mod 24
+2025-07-23 15:01:15 - INFO - Store 2900\uff5cMilk: upserted 12, mod 36
+2025-07-23 15:01:18 - INFO - Store 2900\uff5cMilk: upserted 12, mod 12
+2025-07-23 15:01:21 - INFO - Store 2900\uff5cMilk: upserted 12, mod 24
+2025-07-23 15:01:37 - INFO - Store 2900\uff5cMilk: upserted 12, mod 132
+2025-07-23 15:01:42 - INFO - Store 2900\uff5cMilk: upserted 12, mod 36
+2025-07-23 15:01:43 - INFO - Store 2900\uff5cMilk: upserted 9, mod 0
+2025-07-23 15:01:43 - INFO - Store 2900\uff5cSeasonings: upserted 2, mod 0
+2025-07-23 15:01:44 - INFO - Store 2900\uff5cSeasonings: upserted 5, mod 0
+2025-07-23 15:01:47 - INFO - Store 2900\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 15:01:54 - INFO - Store 2900\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 15:01:56 - INFO - Store 2900\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:01:59 - INFO - Store 2900\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:02:02 - INFO - Store 2900\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 15:02:09 - INFO - Store 2900\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 15:02:10 - INFO - Store 2900\uff5cSeasonings: upserted 9, mod 0
+2025-07-23 15:02:12 - INFO - Store 2900\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:02:17 - INFO - Store 2900\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 15:02:18 - INFO - Store 2900\uff5cSeasonings: upserted 5, mod 0
+2025-07-23 15:02:29 - INFO - Store 2900\uff5cSeasonings: upserted 12, mod 96
+2025-07-23 15:02:32 - INFO - Store 2900\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:02:36 - INFO - Store 2900\uff5cYogurt: upserted 12, mod 36
+2025-07-23 15:02:42 - INFO - Store 2900\uff5cYogurt: upserted 12, mod 48
+2025-07-23 15:02:47 - INFO - Store 2900\uff5cYogurt: upserted 12, mod 48
+2025-07-23 15:02:49 - INFO - Store 2900\uff5cCereals & Grains: upserted 12, mod 12
+2025-07-23 15:02:51 - INFO - Store 2900\uff5cCereals & Grains: upserted 11, mod 13
+2025-07-23 15:02:54 - INFO - Store 2900\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 24
+2025-07-23 15:02:55 - INFO - Store 2900\uff5cCold Cuts: Sausages & Ham: upserted 6, mod 0
+2025-07-23 15:02:57 - INFO - Store 2900\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 15:02:59 - INFO - Store 2900\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 15:03:01 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:03:05 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 15:03:07 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:03:11 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 15:03:12 - INFO - Store 2900\uff5cInstant Foods: upserted 7, mod 0
+2025-07-23 15:03:14 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:03:16 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:03:18 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:03:23 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 15:03:25 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:03:27 - INFO - Store 2900\uff5cInstant Foods: upserted 6, mod 18
+2025-07-23 15:03:29 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:03:30 - INFO - Store 2900\uff5cInstant Foods: upserted 11, mod 0
+2025-07-23 15:03:31 - INFO - Store 2900\uff5cInstant Foods: upserted 11, mod 0
+2025-07-23 15:03:31 - INFO - Store 2900\uff5cInstant Foods: upserted 8, mod 0
+2025-07-23 15:03:35 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 15:03:37 - INFO - Store 2900\uff5cInstant Foods: upserted 11, mod 13
+2025-07-23 15:03:41 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 15:03:43 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:03:44 - INFO - Store 2900\uff5cInstant Foods: upserted 3, mod 2
+2025-07-23 15:03:44 - INFO - Store 2900\uff5cInstant Foods: upserted 8, mod 0
+2025-07-23 15:03:46 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:04:20 - INFO - Store 2900\uff5cInstant Foods: upserted 12, mod 312
+2025-07-23 15:04:22 - INFO - Store 2900\uff5cInstant Foods: upserted 4, mod 20
+2025-07-23 15:04:29 - INFO - Store 2900\uff5cGrains & Staples: upserted 12, mod 48
+2025-07-23 15:04:33 - INFO - Store 2900\uff5cGrains & Staples: upserted 12, mod 24
+2025-07-23 15:04:45 - INFO - Store 2900\uff5cCakes: upserted 12, mod 84
+2025-07-23 15:04:51 - INFO - Store 2900\uff5cCakes: upserted 12, mod 36
+2025-07-23 15:04:52 - INFO - Store 2900\uff5cCakes: upserted 11, mod 0
+2025-07-23 15:04:56 - INFO - Store 2900\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:04:59 - INFO - Store 2900\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:05:01 - INFO - Store 2900\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:05:06 - INFO - Store 2900\uff5cCakes: upserted 12, mod 24
+2025-07-23 15:05:06 - INFO - Store 2900\uff5cCakes: upserted 4, mod 0
+2025-07-23 15:05:07 - INFO - Store 2900\uff5cCakes: upserted 6, mod 0
+2025-07-23 15:05:13 - INFO - Store 2900\uff5cCakes: upserted 12, mod 36
+2025-07-23 15:05:18 - INFO - Store 2900\uff5cCandies: upserted 12, mod 48
+2025-07-23 15:05:20 - INFO - Store 2900\uff5cCandies: upserted 12, mod 12
+2025-07-23 15:05:27 - INFO - Store 2900\uff5cCandies: upserted 12, mod 60
+2025-07-23 15:05:32 - INFO - Store 2900\uff5cDried Fruits: upserted 12, mod 36
+2025-07-23 15:05:34 - INFO - Store 2900\uff5cDried Fruits: upserted 12, mod 12
+2025-07-23 15:05:35 - INFO - Store 2900\uff5cFruit Jam: upserted 7, mod 0
+2025-07-23 15:05:38 - INFO - Store 2900\uff5cSnacks: upserted 12, mod 12
+2025-07-23 15:05:38 - INFO - Store 2477\uff5cFresh Meat: upserted 2, mod 6
+2025-07-23 15:05:39 - INFO - Store 2477\uff5cFresh Meat: upserted 0, mod 1
+2025-07-23 15:05:41 - INFO - Store 2477\uff5cFresh Meat: upserted 0, mod 24
+2025-07-23 15:05:43 - INFO - Store 2477\uff5cFresh Meat: upserted 0, mod 24
+2025-07-23 15:05:44 - INFO - Store 2477\uff5cFresh Meat: upserted 0, mod 9
+2025-07-23 15:05:47 - INFO - Store 2477\uff5cSeafood & Fish Balls: upserted 0, mod 36
+2025-07-23 15:05:53 - INFO - Store 2477\uff5cFresh Fruits: upserted 6, mod 18
+2025-07-23 15:05:54 - INFO - Store 2477\uff5cVegetables: upserted 1, mod 11
+2025-07-23 15:05:57 - INFO - Store 2477\uff5cVegetables: upserted 0, mod 36
+2025-07-23 15:05:58 - INFO - Store 2477\uff5cVegetables: upserted 0, mod 8
+2025-07-23 15:06:00 - INFO - Store 2477\uff5cVegetables: upserted 0, mod 24
+2025-07-23 15:06:04 - INFO - Store 2477\uff5cAlcoholic Beverages: upserted 0, mod 36
+2025-07-23 15:06:14 - INFO - Store 2477\uff5cAlcoholic Beverages: upserted 0, mod 120
+2025-07-23 15:06:19 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 36
+2025-07-23 15:06:31 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 120
+2025-07-23 15:06:40 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 84
+2025-07-23 15:06:43 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 36
+2025-07-23 15:06:47 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 36
+2025-07-23 15:06:52 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 48
+2025-07-23 15:06:53 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 9
+2025-07-23 15:07:00 - INFO - Store 2477\uff5cBeverages: upserted 1, mod 59
+2025-07-23 15:07:13 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 120
+2025-07-23 15:07:16 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 24
+2025-07-23 15:07:18 - INFO - Store 2477\uff5cMilk: upserted 0, mod 24
+2025-07-23 15:07:24 - INFO - Store 2477\uff5cMilk: upserted 0, mod 48
+2025-07-23 15:07:26 - INFO - Store 2477\uff5cMilk: upserted 0, mod 24
+2025-07-23 15:07:31 - INFO - Store 2477\uff5cMilk: upserted 0, mod 36
+2025-07-23 15:07:51 - INFO - Store 2477\uff5cMilk: upserted 0, mod 156
+2025-07-23 15:07:58 - INFO - Store 2477\uff5cMilk: upserted 0, mod 48
+2025-07-23 15:07:58 - INFO - Store 2477\uff5cMilk: upserted 0, mod 1
+2025-07-23 15:07:59 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 1
+2025-07-23 15:07:59 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 2
+2025-07-23 15:08:03 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 15:08:12 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 15:08:16 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:08:19 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:08:23 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 15:08:29 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 15:08:30 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 9
+2025-07-23 15:08:33 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:08:36 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 15:08:37 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 5
+2025-07-23 15:08:48 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 96
+2025-07-23 15:08:50 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:08:52 - INFO - Store 2477\uff5cYogurt: upserted 0, mod 24
+2025-07-23 15:09:00 - INFO - Store 2477\uff5cYogurt: upserted 0, mod 72
+2025-07-23 15:09:02 - INFO - Store 2477\uff5cYogurt: upserted 0, mod 24
+2025-07-23 15:09:03 - INFO - Store 2477\uff5cCereals & Grains: upserted 0, mod 10
+2025-07-23 15:09:05 - INFO - Store 2477\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 15:09:05 - INFO - Store 2477\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 9
+2025-07-23 15:09:06 - INFO - Store 2477\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 3
+2025-07-23 15:09:06 - INFO - Store 2477\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 5
+2025-07-23 15:09:07 - INFO - Store 2477\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 9
+2025-07-23 15:09:09 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 10
+2025-07-23 15:09:13 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 15:09:14 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:09:20 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 15:09:20 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 3
+2025-07-23 15:09:23 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:09:27 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 36
+2025-07-23 15:09:28 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 9
+2025-07-23 15:09:34 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 60
+2025-07-23 15:09:36 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:09:37 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 11
+2025-07-23 15:09:37 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 5
+2025-07-23 15:09:38 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 1
+2025-07-23 15:09:40 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:09:41 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 2
+2025-07-23 15:09:45 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 15:09:47 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:09:50 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 36
+2025-07-23 15:09:51 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 8
+2025-07-23 15:09:51 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 1
+2025-07-23 15:09:51 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 3
+2025-07-23 15:09:52 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 6
+2025-07-23 15:10:30 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 324
+2025-07-23 15:10:32 - INFO - Store 2477\uff5cInstant Foods: upserted 0, mod 5
+2025-07-23 15:10:36 - INFO - Store 2477\uff5cGrains & Staples: upserted 0, mod 48
+2025-07-23 15:10:40 - INFO - Store 2477\uff5cGrains & Staples: upserted 0, mod 36
+2025-07-23 15:10:50 - INFO - Store 2477\uff5cCakes: upserted 0, mod 84
+2025-07-23 15:10:56 - INFO - Store 2477\uff5cCakes: upserted 1, mod 59
+2025-07-23 15:10:57 - INFO - Store 2477\uff5cCakes: upserted 0, mod 9
+2025-07-23 15:11:00 - INFO - Store 2477\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:11:02 - INFO - Store 2477\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:11:05 - INFO - Store 2477\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:11:07 - INFO - Store 2477\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:11:08 - INFO - Store 2477\uff5cCakes: upserted 0, mod 2
+2025-07-23 15:11:08 - INFO - Store 2477\uff5cCakes: upserted 0, mod 3
+2025-07-23 15:11:13 - INFO - Store 2477\uff5cCakes: upserted 0, mod 48
+2025-07-23 15:11:19 - INFO - Store 2477\uff5cCandies: upserted 0, mod 60
+2025-07-23 15:11:21 - INFO - Store 2477\uff5cCandies: upserted 1, mod 23
+2025-07-23 15:11:28 - INFO - Store 2477\uff5cCandies: upserted 0, mod 72
+2025-07-23 15:11:31 - INFO - Store 2477\uff5cDried Fruits: upserted 1, mod 35
+2025-07-23 15:11:33 - INFO - Store 2477\uff5cDried Fruits: upserted 2, mod 22
+2025-07-23 15:11:34 - INFO - Store 2477\uff5cFruit Jam: upserted 0, mod 7
+2025-07-23 15:11:36 - INFO - Store 2477\uff5cSnacks: upserted 0, mod 24
+2025-07-23 15:11:37 - INFO - Store 2379\uff5cFresh Meat: upserted 7, mod 0
+2025-07-23 15:11:37 - INFO - Store 2379\uff5cFresh Meat: upserted 1, mod 0
+2025-07-23 15:11:39 - INFO - Store 2379\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 15:11:42 - INFO - Store 2379\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 15:11:44 - INFO - Store 2379\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 15:11:47 - INFO - Store 2379\uff5cSeafood & Fish Balls: upserted 12, mod 24
+2025-07-23 15:11:50 - INFO - Store 2379\uff5cFresh Fruits: upserted 12, mod 24
+2025-07-23 15:11:53 - INFO - Store 2379\uff5cVegetables: upserted 12, mod 12
+2025-07-23 15:11:57 - INFO - Store 2379\uff5cVegetables: upserted 12, mod 36
+2025-07-23 15:11:58 - INFO - Store 2379\uff5cVegetables: upserted 10, mod 0
+2025-07-23 15:12:01 - INFO - Store 2379\uff5cVegetables: upserted 12, mod 24
+2025-07-23 15:12:06 - INFO - Store 2379\uff5cAlcoholic Beverages: upserted 12, mod 36
+2025-07-23 15:12:18 - INFO - Store 2379\uff5cAlcoholic Beverages: upserted 12, mod 120
+2025-07-23 15:12:24 - INFO - Store 2379\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:12:39 - INFO - Store 2379\uff5cBeverages: upserted 12, mod 120
+2025-07-23 15:12:49 - INFO - Store 2379\uff5cBeverages: upserted 12, mod 84
+2025-07-23 15:12:53 - INFO - Store 2379\uff5cBeverages: upserted 12, mod 24
+2025-07-23 15:13:00 - INFO - Store 2379\uff5cBeverages: upserted 12, mod 48
+2025-07-23 15:13:06 - INFO - Store 2379\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:13:06 - INFO - Store 2379\uff5cBeverages: upserted 9, mod 0
+2025-07-23 15:13:16 - INFO - Store 2379\uff5cBeverages: upserted 12, mod 72
+2025-07-23 15:13:34 - INFO - Store 2379\uff5cBeverages: upserted 12, mod 132
+2025-07-23 15:13:34 - INFO - Store 2379\uff5cBeverages: upserted 12, mod 0
+2025-07-23 15:13:38 - INFO - Store 2379\uff5cMilk: upserted 12, mod 24
+2025-07-23 15:13:45 - INFO - Store 2379\uff5cMilk: upserted 12, mod 48
+2025-07-23 15:13:48 - INFO - Store 2379\uff5cMilk: upserted 12, mod 12
+2025-07-23 15:13:53 - INFO - Store 2379\uff5cMilk: upserted 12, mod 36
+2025-07-23 15:14:13 - INFO - Store 2379\uff5cMilk: upserted 12, mod 156
+2025-07-23 15:14:18 - INFO - Store 2379\uff5cMilk: upserted 12, mod 36
+2025-07-23 15:14:19 - INFO - Store 2379\uff5cMilk: upserted 2, mod 0
+2025-07-23 15:14:19 - INFO - Store 2379\uff5cSeasonings: upserted 1, mod 0
+2025-07-23 15:14:19 - INFO - Store 2379\uff5cSeasonings: upserted 3, mod 0
+2025-07-23 15:14:23 - INFO - Store 2379\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 15:14:28 - INFO - Store 2379\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 15:14:31 - INFO - Store 2379\uff5cSeasonings: upserted 10, mod 0
+2025-07-23 15:14:33 - INFO - Store 2379\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:14:37 - INFO - Store 2379\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 15:14:42 - INFO - Store 2379\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 15:14:43 - INFO - Store 2379\uff5cSeasonings: upserted 10, mod 0
+2025-07-23 15:14:46 - INFO - Store 2379\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:14:51 - INFO - Store 2379\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 15:14:52 - INFO - Store 2379\uff5cSeasonings: upserted 4, mod 0
+2025-07-23 15:15:03 - INFO - Store 2379\uff5cSeasonings: upserted 12, mod 84
+2025-07-23 15:15:07 - INFO - Store 2379\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:15:08 - INFO - Store 2379\uff5cYogurt: upserted 12, mod 0
+2025-07-23 15:15:17 - INFO - Store 2379\uff5cYogurt: upserted 12, mod 72
+2025-07-23 15:15:19 - INFO - Store 2379\uff5cYogurt: upserted 12, mod 12
+2025-07-23 15:15:22 - INFO - Store 2379\uff5cCereals & Grains: upserted 11, mod 0
+2025-07-23 15:15:25 - INFO - Store 2379\uff5cCereals & Grains: upserted 9, mod 15
+2025-07-23 15:15:26 - INFO - Store 2379\uff5cCold Cuts: Sausages & Ham: upserted 11, mod 0
+2025-07-23 15:15:26 - INFO - Store 2379\uff5cCold Cuts: Sausages & Ham: upserted 5, mod 0
+2025-07-23 15:15:27 - INFO - Store 2379\uff5cCold Cuts: Sausages & Ham: upserted 6, mod 0
+2025-07-23 15:15:27 - INFO - Store 2379\uff5cCold Cuts: Sausages & Ham: upserted 8, mod 0
+2025-07-23 15:15:29 - INFO - Store 2379\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:15:33 - INFO - Store 2379\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 15:15:35 - INFO - Store 2379\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:15:39 - INFO - Store 2379\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 15:15:40 - INFO - Store 2379\uff5cInstant Foods: upserted 3, mod 0
+2025-07-23 15:15:41 - INFO - Store 2379\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:15:49 - INFO - Store 2379\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 15:15:50 - INFO - Store 2379\uff5cInstant Foods: upserted 10, mod 0
+2025-07-23 15:15:55 - INFO - Store 2379\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 15:15:57 - INFO - Store 2379\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:15:58 - INFO - Store 2379\uff5cInstant Foods: upserted 9, mod 15
+2025-07-23 15:15:59 - INFO - Store 2379\uff5cInstant Foods: upserted 4, mod 0
+2025-07-23 15:15:59 - INFO - Store 2379\uff5cInstant Foods: upserted 2, mod 0
+2025-07-23 15:16:01 - INFO - Store 2379\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:16:01 - INFO - Store 2379\uff5cInstant Foods: upserted 4, mod 1
+2025-07-23 15:16:05 - INFO - Store 2379\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 15:16:07 - INFO - Store 2379\uff5cInstant Foods: upserted 11, mod 13
+2025-07-23 15:16:10 - INFO - Store 2379\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 15:16:11 - INFO - Store 2379\uff5cInstant Foods: upserted 8, mod 0
+2025-07-23 15:16:11 - INFO - Store 2379\uff5cInstant Foods: upserted 1, mod 0
+2025-07-23 15:16:12 - INFO - Store 2379\uff5cInstant Foods: upserted 4, mod 1
+2025-07-23 15:16:12 - INFO - Store 2379\uff5cInstant Foods: upserted 6, mod 0
+2025-07-23 15:16:41 - INFO - Store 2379\uff5cInstant Foods: upserted 12, mod 324
+2025-07-23 15:16:43 - INFO - Store 2379\uff5cInstant Foods: upserted 2, mod 2
+2025-07-23 15:16:47 - INFO - Store 2379\uff5cGrains & Staples: upserted 12, mod 36
+2025-07-23 15:16:51 - INFO - Store 2379\uff5cGrains & Staples: upserted 12, mod 24
+2025-07-23 15:17:01 - INFO - Store 2379\uff5cCakes: upserted 12, mod 84
+2025-07-23 15:17:07 - INFO - Store 2379\uff5cCakes: upserted 12, mod 36
+2025-07-23 15:17:08 - INFO - Store 2379\uff5cCakes: upserted 12, mod 0
+2025-07-23 15:17:11 - INFO - Store 2379\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:17:13 - INFO - Store 2379\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:17:16 - INFO - Store 2379\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:17:22 - INFO - Store 2379\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:17:22 - INFO - Store 2379\uff5cCakes: upserted 3, mod 0
+2025-07-23 15:17:23 - INFO - Store 2379\uff5cCakes: upserted 4, mod 0
+2025-07-23 15:17:28 - INFO - Store 2379\uff5cCakes: upserted 12, mod 36
+2025-07-23 15:17:34 - INFO - Store 2379\uff5cCandies: upserted 12, mod 48
+2025-07-23 15:17:36 - INFO - Store 2379\uff5cCandies: upserted 12, mod 12
+2025-07-23 15:17:43 - INFO - Store 2379\uff5cCandies: upserted 12, mod 60
+2025-07-23 15:17:48 - INFO - Store 2379\uff5cDried Fruits: upserted 12, mod 36
+2025-07-23 15:17:51 - INFO - Store 2379\uff5cDried Fruits: upserted 12, mod 24
+2025-07-23 15:17:51 - INFO - Store 2379\uff5cFruit Jam: upserted 8, mod 0
+2025-07-23 15:17:53 - INFO - Store 2379\uff5cSnacks: upserted 12, mod 12
+2025-07-23 15:17:54 - INFO - Store 3652\uff5cFresh Meat: upserted 7, mod 0
+2025-07-23 15:17:54 - INFO - Store 3652\uff5cFresh Meat: upserted 1, mod 0
+2025-07-23 15:17:57 - INFO - Store 3652\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 15:17:59 - INFO - Store 3652\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 15:18:01 - INFO - Store 3652\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 15:18:06 - INFO - Store 3652\uff5cSeafood & Fish Balls: upserted 12, mod 36
+2025-07-23 15:18:10 - INFO - Store 3652\uff5cFresh Fruits: upserted 12, mod 36
+2025-07-23 15:18:12 - INFO - Store 3652\uff5cVegetables: upserted 12, mod 12
+2025-07-23 15:18:18 - INFO - Store 3652\uff5cVegetables: upserted 12, mod 48
+2025-07-23 15:18:19 - INFO - Store 3652\uff5cVegetables: upserted 12, mod 0
+2025-07-23 15:18:22 - INFO - Store 3652\uff5cVegetables: upserted 12, mod 24
+2025-07-23 15:18:27 - INFO - Store 3652\uff5cAlcoholic Beverages: upserted 12, mod 36
+2025-07-23 15:18:40 - INFO - Store 3652\uff5cAlcoholic Beverages: upserted 12, mod 132
+2025-07-23 15:18:46 - INFO - Store 3652\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:18:59 - INFO - Store 3652\uff5cBeverages: upserted 12, mod 108
+2025-07-23 15:19:11 - INFO - Store 3652\uff5cBeverages: upserted 12, mod 96
+2025-07-23 15:19:15 - INFO - Store 3652\uff5cBeverages: upserted 12, mod 24
+2025-07-23 15:19:21 - INFO - Store 3652\uff5cBeverages: upserted 12, mod 48
+2025-07-23 15:19:25 - INFO - Store 3652\uff5cBeverages: upserted 12, mod 24
+2025-07-23 15:19:26 - INFO - Store 3652\uff5cBeverages: upserted 6, mod 0
+2025-07-23 15:19:36 - INFO - Store 3652\uff5cBeverages: upserted 12, mod 72
+2025-07-23 15:19:52 - INFO - Store 3652\uff5cBeverages: upserted 12, mod 120
+2025-07-23 15:19:53 - INFO - Store 3652\uff5cBeverages: upserted 7, mod 0
+2025-07-23 15:19:58 - INFO - Store 3652\uff5cMilk: upserted 12, mod 24
+2025-07-23 15:20:07 - INFO - Store 3652\uff5cMilk: upserted 12, mod 36
+2025-07-23 15:20:11 - INFO - Store 3652\uff5cMilk: upserted 12, mod 12
+2025-07-23 15:20:15 - INFO - Store 3652\uff5cMilk: upserted 12, mod 24
+2025-07-23 15:20:30 - INFO - Store 3652\uff5cMilk: upserted 12, mod 120
+2025-07-23 15:20:35 - INFO - Store 3652\uff5cMilk: upserted 12, mod 36
+2025-07-23 15:20:36 - INFO - Store 3652\uff5cMilk: upserted 1, mod 0
+2025-07-23 15:20:36 - INFO - Store 3652\uff5cSeasonings: upserted 1, mod 0
+2025-07-23 15:20:36 - INFO - Store 3652\uff5cSeasonings: upserted 2, mod 0
+2025-07-23 15:20:40 - INFO - Store 3652\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 15:20:48 - INFO - Store 3652\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 15:20:50 - INFO - Store 3652\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:20:51 - INFO - Store 3652\uff5cSeasonings: upserted 11, mod 0
+2025-07-23 15:20:55 - INFO - Store 3652\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 15:20:58 - INFO - Store 3652\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 15:20:59 - INFO - Store 3652\uff5cSeasonings: upserted 9, mod 0
+2025-07-23 15:21:04 - INFO - Store 3652\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:21:09 - INFO - Store 3652\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 15:21:10 - INFO - Store 3652\uff5cSeasonings: upserted 5, mod 0
+2025-07-23 15:21:21 - INFO - Store 3652\uff5cSeasonings: upserted 12, mod 84
+2025-07-23 15:21:23 - INFO - Store 3652\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:21:32 - INFO - Store 3652\uff5cYogurt: upserted 12, mod 12
+2025-07-23 15:21:37 - INFO - Store 3652\uff5cYogurt: upserted 12, mod 48
+2025-07-23 15:21:39 - INFO - Store 3652\uff5cYogurt: upserted 12, mod 12
+2025-07-23 15:21:39 - INFO - Store 3652\uff5cCereals & Grains: upserted 5, mod 0
+2025-07-23 15:21:41 - INFO - Store 3652\uff5cCereals & Grains: upserted 10, mod 14
+2025-07-23 15:21:45 - INFO - Store 3652\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 15:21:46 - INFO - Store 3652\uff5cCold Cuts: Sausages & Ham: upserted 5, mod 0
+2025-07-23 15:21:48 - INFO - Store 3652\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 15:21:49 - INFO - Store 3652\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 0
+2025-07-23 15:21:49 - INFO - Store 3652\uff5cInstant Foods: upserted 12, mod 0
+2025-07-23 15:21:54 - INFO - Store 3652\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 15:21:56 - INFO - Store 3652\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:22:00 - INFO - Store 3652\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 15:22:01 - INFO - Store 3652\uff5cInstant Foods: upserted 3, mod 0
+2025-07-23 15:22:03 - INFO - Store 3652\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:22:05 - INFO - Store 3652\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:22:06 - INFO - Store 3652\uff5cInstant Foods: upserted 8, mod 0
+2025-07-23 15:22:10 - INFO - Store 3652\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 15:22:12 - INFO - Store 3652\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:22:13 - INFO - Store 3652\uff5cInstant Foods: upserted 10, mod 1
+2025-07-23 15:22:13 - INFO - Store 3652\uff5cInstant Foods: upserted 7, mod 0
+2025-07-23 15:22:14 - INFO - Store 3652\uff5cInstant Foods: upserted 5, mod 0
+2025-07-23 15:22:16 - INFO - Store 3652\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:22:16 - INFO - Store 3652\uff5cInstant Foods: upserted 5, mod 1
+2025-07-23 15:22:20 - INFO - Store 3652\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 15:22:22 - INFO - Store 3652\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:22:25 - INFO - Store 3652\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 15:22:26 - INFO - Store 3652\uff5cInstant Foods: upserted 8, mod 0
+2025-07-23 15:22:26 - INFO - Store 3652\uff5cInstant Foods: upserted 1, mod 0
+2025-07-23 15:22:27 - INFO - Store 3652\uff5cInstant Foods: upserted 4, mod 1
+2025-07-23 15:22:27 - INFO - Store 3652\uff5cInstant Foods: upserted 7, mod 0
+2025-07-23 15:22:59 - INFO - Store 3652\uff5cInstant Foods: upserted 12, mod 300
+2025-07-23 15:23:01 - INFO - Store 3652\uff5cInstant Foods: upserted 3, mod 6
+2025-07-23 15:23:06 - INFO - Store 3652\uff5cGrains & Staples: upserted 12, mod 36
+2025-07-23 15:23:08 - INFO - Store 3652\uff5cGrains & Staples: upserted 12, mod 12
+2025-07-23 15:23:17 - INFO - Store 3652\uff5cCakes: upserted 12, mod 72
+2025-07-23 15:23:23 - INFO - Store 3652\uff5cCakes: upserted 12, mod 36
+2025-07-23 15:23:24 - INFO - Store 3652\uff5cCakes: upserted 8, mod 0
+2025-07-23 15:23:26 - INFO - Store 3652\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:23:27 - INFO - Store 3652\uff5cCakes: upserted 9, mod 0
+2025-07-23 15:23:29 - INFO - Store 3652\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:23:31 - INFO - Store 3652\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:23:32 - INFO - Store 3652\uff5cCakes: upserted 3, mod 0
+2025-07-23 15:23:34 - INFO - Store 3652\uff5cCakes: upserted 5, mod 0
+2025-07-23 15:23:37 - INFO - Store 3652\uff5cCakes: upserted 12, mod 24
+2025-07-23 15:23:42 - INFO - Store 3652\uff5cCandies: upserted 12, mod 36
+2025-07-23 15:23:43 - INFO - Store 3652\uff5cCandies: upserted 11, mod 0
+2025-07-23 15:23:48 - INFO - Store 3652\uff5cCandies: upserted 12, mod 48
+2025-07-23 15:23:51 - INFO - Store 3652\uff5cDried Fruits: upserted 12, mod 24
+2025-07-23 15:23:53 - INFO - Store 3652\uff5cDried Fruits: upserted 12, mod 12
+2025-07-23 15:23:54 - INFO - Store 3652\uff5cFruit Jam: upserted 5, mod 0
+2025-07-23 15:23:56 - INFO - Store 3652\uff5cSnacks: upserted 12, mod 12
+2025-07-23 15:23:57 - INFO - Store 2470\uff5cFresh Meat: upserted 7, mod 0
+2025-07-23 15:23:57 - INFO - Store 2470\uff5cFresh Meat: upserted 2, mod 0
+2025-07-23 15:24:00 - INFO - Store 2470\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 15:24:04 - INFO - Store 2470\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 15:24:05 - INFO - Store 2470\uff5cFresh Meat: upserted 11, mod 0
+2025-07-23 15:24:05 - INFO - Store 2470\uff5cSeafood & Fish Balls: upserted 6, mod 0
+2025-07-23 15:24:11 - INFO - Store 2470\uff5cFresh Fruits: upserted 12, mod 36
+2025-07-23 15:24:13 - INFO - Store 2470\uff5cVegetables: upserted 12, mod 12
+2025-07-23 15:24:18 - INFO - Store 2470\uff5cVegetables: upserted 12, mod 36
+2025-07-23 15:24:18 - INFO - Store 2470\uff5cVegetables: upserted 7, mod 0
+2025-07-23 15:24:28 - INFO - Store 2470\uff5cVegetables: upserted 12, mod 24
+2025-07-23 15:24:31 - INFO - Store 2470\uff5cAlcoholic Beverages: upserted 12, mod 24
+2025-07-23 15:24:43 - INFO - Store 2470\uff5cAlcoholic Beverages: upserted 12, mod 108
+2025-07-23 15:24:48 - INFO - Store 2470\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:25:02 - INFO - Store 2470\uff5cBeverages: upserted 12, mod 120
+2025-07-23 15:25:14 - INFO - Store 2470\uff5cBeverages: upserted 12, mod 84
+2025-07-23 15:25:20 - INFO - Store 2470\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:25:29 - INFO - Store 2470\uff5cBeverages: upserted 12, mod 60
+2025-07-23 15:25:34 - INFO - Store 2470\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:25:35 - INFO - Store 2470\uff5cBeverages: upserted 6, mod 0
+2025-07-23 15:25:46 - INFO - Store 2470\uff5cBeverages: upserted 12, mod 72
+2025-07-23 15:26:03 - INFO - Store 2470\uff5cBeverages: upserted 12, mod 120
+2025-07-23 15:26:04 - INFO - Store 2470\uff5cBeverages: upserted 11, mod 0
+2025-07-23 15:26:08 - INFO - Store 2470\uff5cMilk: upserted 12, mod 24
+2025-07-23 15:26:14 - INFO - Store 2470\uff5cMilk: upserted 12, mod 48
+2025-07-23 15:26:18 - INFO - Store 2470\uff5cMilk: upserted 12, mod 12
+2025-07-23 15:26:22 - INFO - Store 2470\uff5cMilk: upserted 12, mod 24
+2025-07-23 15:26:40 - INFO - Store 2470\uff5cMilk: upserted 12, mod 156
+2025-07-23 15:26:45 - INFO - Store 2470\uff5cMilk: upserted 12, mod 36
+2025-07-23 15:26:45 - INFO - Store 2470\uff5cMilk: upserted 3, mod 0
+2025-07-23 15:26:46 - INFO - Store 2470\uff5cSeasonings: upserted 1, mod 0
+2025-07-23 15:26:46 - INFO - Store 2470\uff5cSeasonings: upserted 3, mod 0
+2025-07-23 15:26:49 - INFO - Store 2470\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 15:26:56 - INFO - Store 2470\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 15:26:58 - INFO - Store 2470\uff5cSeasonings: upserted 11, mod 0
+2025-07-23 15:27:00 - INFO - Store 2470\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:27:04 - INFO - Store 2470\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 15:27:09 - INFO - Store 2470\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 15:27:10 - INFO - Store 2470\uff5cSeasonings: upserted 8, mod 1
+2025-07-23 15:27:12 - INFO - Store 2470\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:27:17 - INFO - Store 2470\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 15:27:18 - INFO - Store 2470\uff5cSeasonings: upserted 4, mod 0
+2025-07-23 15:27:30 - INFO - Store 2470\uff5cSeasonings: upserted 12, mod 96
+2025-07-23 15:27:32 - INFO - Store 2470\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:27:36 - INFO - Store 2470\uff5cYogurt: upserted 12, mod 24
+2025-07-23 15:27:44 - INFO - Store 2470\uff5cYogurt: upserted 12, mod 72
+2025-07-23 15:27:48 - INFO - Store 2470\uff5cYogurt: upserted 12, mod 24
+2025-07-23 15:27:50 - INFO - Store 2470\uff5cCereals & Grains: upserted 12, mod 12
+2025-07-23 15:27:52 - INFO - Store 2470\uff5cCereals & Grains: upserted 11, mod 13
+2025-07-23 15:27:53 - INFO - Store 2470\uff5cCold Cuts: Sausages & Ham: upserted 8, mod 0
+2025-07-23 15:27:54 - INFO - Store 2470\uff5cCold Cuts: Sausages & Ham: upserted 5, mod 0
+2025-07-23 15:27:54 - INFO - Store 2470\uff5cCold Cuts: Sausages & Ham: upserted 6, mod 0
+2025-07-23 15:27:55 - INFO - Store 2470\uff5cCold Cuts: Sausages & Ham: upserted 9, mod 0
+2025-07-23 15:27:57 - INFO - Store 2470\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:28:01 - INFO - Store 2470\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 15:28:03 - INFO - Store 2470\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:28:07 - INFO - Store 2470\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 15:28:07 - INFO - Store 2470\uff5cInstant Foods: upserted 2, mod 0
+2025-07-23 15:28:09 - INFO - Store 2470\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:28:11 - INFO - Store 2470\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:28:12 - INFO - Store 2470\uff5cInstant Foods: upserted 7, mod 0
+2025-07-23 15:28:17 - INFO - Store 2470\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 15:28:19 - INFO - Store 2470\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:28:19 - INFO - Store 2470\uff5cInstant Foods: upserted 9, mod 1
+2025-07-23 15:28:20 - INFO - Store 2470\uff5cInstant Foods: upserted 3, mod 0
+2025-07-23 15:28:20 - INFO - Store 2470\uff5cInstant Foods: upserted 2, mod 0
+2025-07-23 15:28:22 - INFO - Store 2470\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:28:22 - INFO - Store 2470\uff5cInstant Foods: upserted 5, mod 0
+2025-07-23 15:28:25 - INFO - Store 2470\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 15:28:27 - INFO - Store 2470\uff5cInstant Foods: upserted 11, mod 13
+2025-07-23 15:28:30 - INFO - Store 2470\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 15:28:31 - INFO - Store 2470\uff5cInstant Foods: upserted 6, mod 0
+2025-07-23 15:28:31 - INFO - Store 2470\uff5cInstant Foods: upserted 1, mod 0
+2025-07-23 15:28:32 - INFO - Store 2470\uff5cInstant Foods: upserted 3, mod 0
+2025-07-23 15:28:32 - INFO - Store 2470\uff5cInstant Foods: upserted 4, mod 0
+2025-07-23 15:29:01 - INFO - Store 2470\uff5cInstant Foods: upserted 12, mod 324
+2025-07-23 15:29:03 - INFO - Store 2470\uff5cInstant Foods: upserted 3, mod 2
+2025-07-23 15:29:08 - INFO - Store 2470\uff5cGrains & Staples: upserted 12, mod 48
+2025-07-23 15:29:12 - INFO - Store 2470\uff5cGrains & Staples: upserted 12, mod 24
+2025-07-23 15:29:21 - INFO - Store 2470\uff5cCakes: upserted 12, mod 72
+2025-07-23 15:29:24 - INFO - Store 2470\uff5cCakes: upserted 12, mod 24
+2025-07-23 15:29:25 - INFO - Store 2470\uff5cCakes: upserted 9, mod 0
+2025-07-23 15:29:28 - INFO - Store 2470\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:29:30 - INFO - Store 2470\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:29:32 - INFO - Store 2470\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:29:34 - INFO - Store 2470\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:29:35 - INFO - Store 2470\uff5cCakes: upserted 3, mod 0
+2025-07-23 15:29:35 - INFO - Store 2470\uff5cCakes: upserted 4, mod 0
+2025-07-23 15:29:40 - INFO - Store 2470\uff5cCakes: upserted 12, mod 36
+2025-07-23 15:29:47 - INFO - Store 2470\uff5cCandies: upserted 12, mod 48
+2025-07-23 15:29:48 - INFO - Store 2470\uff5cCandies: upserted 10, mod 0
+2025-07-23 15:29:55 - INFO - Store 2470\uff5cCandies: upserted 12, mod 60
+2025-07-23 15:30:00 - INFO - Store 2470\uff5cDried Fruits: upserted 12, mod 36
+2025-07-23 15:30:02 - INFO - Store 2470\uff5cDried Fruits: upserted 12, mod 12
+2025-07-23 15:30:03 - INFO - Store 2470\uff5cFruit Jam: upserted 7, mod 0
+2025-07-23 15:30:05 - INFO - Store 2470\uff5cSnacks: upserted 12, mod 12
+2025-07-23 15:30:05 - INFO - Store 2713\uff5cFresh Meat: upserted 1, mod 5
+2025-07-23 15:30:06 - INFO - Store 2713\uff5cFresh Meat: upserted 0, mod 6
+2025-07-23 15:30:09 - INFO - Store 2713\uff5cFresh Meat: upserted 1, mod 35
+2025-07-23 15:30:11 - INFO - Store 2713\uff5cFresh Meat: upserted 0, mod 24
+2025-07-23 15:30:13 - INFO - Store 2713\uff5cFresh Meat: upserted 0, mod 24
+2025-07-23 15:30:19 - INFO - Store 2713\uff5cSeafood & Fish Balls: upserted 1, mod 47
+2025-07-23 15:30:23 - INFO - Store 2713\uff5cFresh Fruits: upserted 1, mod 35
+2025-07-23 15:30:24 - INFO - Store 2713\uff5cVegetables: upserted 1, mod 11
+2025-07-23 15:30:31 - INFO - Store 2713\uff5cVegetables: upserted 0, mod 60
+2025-07-23 15:30:32 - INFO - Store 2713\uff5cVegetables: upserted 0, mod 12
+2025-07-23 15:30:35 - INFO - Store 2713\uff5cVegetables: upserted 0, mod 36
+2025-07-23 15:30:40 - INFO - Store 2713\uff5cAlcoholic Beverages: upserted 0, mod 48
+2025-07-23 15:30:52 - INFO - Store 2713\uff5cAlcoholic Beverages: upserted 0, mod 132
+2025-07-23 15:30:57 - INFO - Store 2713\uff5cBeverages: upserted 0, mod 48
+2025-07-23 15:31:12 - INFO - Store 2713\uff5cBeverages: upserted 0, mod 132
+2025-07-23 15:31:22 - INFO - Store 2713\uff5cBeverages: upserted 0, mod 96
+2025-07-23 15:31:28 - INFO - Store 2713\uff5cBeverages: upserted 0, mod 48
+2025-07-23 15:31:37 - INFO - Store 2713\uff5cBeverages: upserted 0, mod 72
+2025-07-23 15:31:42 - INFO - Store 2713\uff5cBeverages: upserted 1, mod 47
+2025-07-23 15:31:43 - INFO - Store 2713\uff5cBeverages: upserted 0, mod 7
+2025-07-23 15:31:51 - INFO - Store 2713\uff5cBeverages: upserted 0, mod 84
+2025-07-23 15:32:08 - INFO - Store 2713\uff5cBeverages: upserted 0, mod 144
+2025-07-23 15:32:11 - INFO - Store 2713\uff5cBeverages: upserted 2, mod 22
+2025-07-23 15:32:14 - INFO - Store 2713\uff5cMilk: upserted 0, mod 36
+2025-07-23 15:32:20 - INFO - Store 2713\uff5cMilk: upserted 0, mod 60
+2025-07-23 15:32:23 - INFO - Store 2713\uff5cMilk: upserted 0, mod 24
+2025-07-23 15:32:26 - INFO - Store 2713\uff5cMilk: upserted 0, mod 36
+2025-07-23 15:32:44 - INFO - Store 2713\uff5cMilk: upserted 0, mod 168
+2025-07-23 15:32:49 - INFO - Store 2713\uff5cMilk: upserted 0, mod 48
+2025-07-23 15:32:50 - INFO - Store 2713\uff5cMilk: upserted 0, mod 10
+2025-07-23 15:32:50 - INFO - Store 2713\uff5cSeasonings: upserted 0, mod 1
+2025-07-23 15:32:50 - INFO - Store 2713\uff5cSeasonings: upserted 0, mod 2
+2025-07-23 15:32:54 - INFO - Store 2713\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 15:32:59 - INFO - Store 2713\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 15:33:02 - INFO - Store 2713\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:33:04 - INFO - Store 2713\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:33:08 - INFO - Store 2713\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 15:33:14 - INFO - Store 2713\uff5cSeasonings: upserted 1, mod 47
+2025-07-23 15:33:14 - INFO - Store 2713\uff5cSeasonings: upserted 0, mod 8
+2025-07-23 15:33:17 - INFO - Store 2713\uff5cSeasonings: upserted 1, mod 23
+2025-07-23 15:33:22 - INFO - Store 2713\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 15:33:22 - INFO - Store 2713\uff5cSeasonings: upserted 0, mod 4
+2025-07-23 15:33:33 - INFO - Store 2713\uff5cSeasonings: upserted 0, mod 96
+2025-07-23 15:33:35 - INFO - Store 2713\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:33:39 - INFO - Store 2713\uff5cYogurt: upserted 2, mod 46
+2025-07-23 15:33:47 - INFO - Store 2713\uff5cYogurt: upserted 0, mod 84
+2025-07-23 15:33:52 - INFO - Store 2713\uff5cYogurt: upserted 0, mod 60
+2025-07-23 15:33:56 - INFO - Store 2713\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 15:33:58 - INFO - Store 2713\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 15:34:00 - INFO - Store 2713\uff5cCold Cuts: Sausages & Ham: upserted 1, mod 23
+2025-07-23 15:34:01 - INFO - Store 2713\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 5
+2025-07-23 15:34:02 - INFO - Store 2713\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 4
+2025-07-23 15:34:02 - INFO - Store 2713\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 12
+2025-07-23 15:34:05 - INFO - Store 2713\uff5cInstant Foods: upserted 2, mod 22
+2025-07-23 15:34:09 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 15:34:11 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:34:15 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 15:34:16 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 6
+2025-07-23 15:34:18 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:34:20 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:34:20 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 8
+2025-07-23 15:34:26 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 60
+2025-07-23 15:34:28 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:34:30 - INFO - Store 2713\uff5cInstant Foods: upserted 1, mod 23
+2025-07-23 15:34:30 - INFO - Store 2713\uff5cInstant Foods: upserted 1, mod 7
+2025-07-23 15:34:31 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 5
+2025-07-23 15:34:33 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:34:33 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 5
+2025-07-23 15:34:38 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 15:34:40 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:34:43 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 36
+2025-07-23 15:34:43 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 9
+2025-07-23 15:34:44 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 3
+2025-07-23 15:34:44 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 4
+2025-07-23 15:34:45 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 9
+2025-07-23 15:35:14 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 336
+2025-07-23 15:35:15 - INFO - Store 2713\uff5cInstant Foods: upserted 0, mod 10
+2025-07-23 15:35:21 - INFO - Store 2713\uff5cGrains & Staples: upserted 0, mod 60
+2025-07-23 15:35:24 - INFO - Store 2713\uff5cGrains & Staples: upserted 0, mod 36
+2025-07-23 15:35:32 - INFO - Store 2713\uff5cCakes: upserted 1, mod 83
+2025-07-23 15:35:39 - INFO - Store 2713\uff5cCakes: upserted 1, mod 47
+2025-07-23 15:35:40 - INFO - Store 2713\uff5cCakes: upserted 0, mod 11
+2025-07-23 15:35:42 - INFO - Store 2713\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:35:45 - INFO - Store 2713\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:35:47 - INFO - Store 2713\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:35:50 - INFO - Store 2713\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:35:50 - INFO - Store 2713\uff5cCakes: upserted 0, mod 3
+2025-07-23 15:35:51 - INFO - Store 2713\uff5cCakes: upserted 0, mod 6
+2025-07-23 15:35:57 - INFO - Store 2713\uff5cCakes: upserted 0, mod 48
+2025-07-23 15:36:03 - INFO - Store 2713\uff5cCandies: upserted 1, mod 47
+2025-07-23 15:36:04 - INFO - Store 2713\uff5cCandies: upserted 0, mod 11
+2025-07-23 15:36:11 - INFO - Store 2713\uff5cCandies: upserted 1, mod 71
+2025-07-23 15:36:14 - INFO - Store 2713\uff5cDried Fruits: upserted 0, mod 36
+2025-07-23 15:36:17 - INFO - Store 2713\uff5cDried Fruits: upserted 3, mod 21
+2025-07-23 15:36:19 - INFO - Store 2713\uff5cFruit Jam: upserted 0, mod 7
+2025-07-23 15:36:21 - INFO - Store 2713\uff5cSnacks: upserted 0, mod 24
+2025-07-23 15:36:22 - INFO - Store 2422\uff5cFresh Meat: upserted 0, mod 8
+2025-07-23 15:36:26 - INFO - Store 2422\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 15:36:29 - INFO - Store 2422\uff5cFresh Meat: upserted 4, mod 20
+2025-07-23 15:36:29 - INFO - Store 2422\uff5cFresh Meat: upserted 0, mod 11
+2025-07-23 15:36:33 - INFO - Store 2422\uff5cSeafood & Fish Balls: upserted 1, mod 47
+2025-07-23 15:36:38 - INFO - Store 2422\uff5cFresh Fruits: upserted 0, mod 48
+2025-07-23 15:36:40 - INFO - Store 2422\uff5cVegetables: upserted 1, mod 23
+2025-07-23 15:36:46 - INFO - Store 2422\uff5cVegetables: upserted 1, mod 59
+2025-07-23 15:36:48 - INFO - Store 2422\uff5cVegetables: upserted 1, mod 23
+2025-07-23 15:36:51 - INFO - Store 2422\uff5cVegetables: upserted 0, mod 36
+2025-07-23 15:36:55 - INFO - Store 2422\uff5cAlcoholic Beverages: upserted 0, mod 48
+2025-07-23 15:37:07 - INFO - Store 2422\uff5cAlcoholic Beverages: upserted 0, mod 132
+2025-07-23 15:37:13 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 48
+2025-07-23 15:37:24 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 108
+2025-07-23 15:37:31 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 60
+2025-07-23 15:37:37 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 48
+2025-07-23 15:37:42 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 60
+2025-07-23 15:37:48 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 48
+2025-07-23 15:37:49 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 8
+2025-07-23 15:37:56 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 60
+2025-07-23 15:38:09 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 120
+2025-07-23 15:38:10 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 11
+2025-07-23 15:38:12 - INFO - Store 2422\uff5cMilk: upserted 0, mod 24
+2025-07-23 15:38:19 - INFO - Store 2422\uff5cMilk: upserted 0, mod 60
+2025-07-23 15:38:22 - INFO - Store 2422\uff5cMilk: upserted 0, mod 24
+2025-07-23 15:38:25 - INFO - Store 2422\uff5cMilk: upserted 0, mod 36
+2025-07-23 15:38:42 - INFO - Store 2422\uff5cMilk: upserted 0, mod 156
+2025-07-23 15:38:47 - INFO - Store 2422\uff5cMilk: upserted 0, mod 48
+2025-07-23 15:38:47 - INFO - Store 2422\uff5cMilk: upserted 0, mod 4
+2025-07-23 15:38:48 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 1
+2025-07-23 15:38:48 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 1
+2025-07-23 15:38:51 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 15:38:58 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 60
+2025-07-23 15:39:00 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:39:02 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:39:06 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 15:39:12 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 60
+2025-07-23 15:39:13 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 7
+2025-07-23 15:39:15 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:39:21 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 15:39:21 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 4
+2025-07-23 15:39:32 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 96
+2025-07-23 15:39:34 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:39:37 - INFO - Store 2422\uff5cYogurt: upserted 2, mod 34
+2025-07-23 15:39:44 - INFO - Store 2422\uff5cYogurt: upserted 0, mod 72
+2025-07-23 15:39:49 - INFO - Store 2422\uff5cYogurt: upserted 1, mod 47
+2025-07-23 15:39:51 - INFO - Store 2422\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 15:39:53 - INFO - Store 2422\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 15:39:55 - INFO - Store 2422\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 24
+2025-07-23 15:39:55 - INFO - Store 2422\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 3
+2025-07-23 15:39:56 - INFO - Store 2422\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 10
+2025-07-23 15:39:58 - INFO - Store 2422\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 24
+2025-07-23 15:39:59 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 10
+2025-07-23 15:40:03 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 15:40:05 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:40:09 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 15:40:09 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 3
+2025-07-23 15:40:11 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:40:13 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:40:15 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:40:20 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 60
+2025-07-23 15:40:22 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:40:24 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:40:25 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 12
+2025-07-23 15:40:25 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 6
+2025-07-23 15:40:27 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:40:29 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:40:33 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 15:40:35 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:40:38 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 36
+2025-07-23 15:40:40 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:40:40 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 2
+2025-07-23 15:40:40 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 5
+2025-07-23 15:40:41 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 6
+2025-07-23 15:41:08 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 324
+2025-07-23 15:41:11 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 11
+2025-07-23 15:41:15 - INFO - Store 2422\uff5cGrains & Staples: upserted 0, mod 48
+2025-07-23 15:41:18 - INFO - Store 2422\uff5cGrains & Staples: upserted 0, mod 36
+2025-07-23 15:41:27 - INFO - Store 2422\uff5cCakes: upserted 0, mod 84
+2025-07-23 15:41:32 - INFO - Store 2422\uff5cCakes: upserted 0, mod 48
+2025-07-23 15:41:32 - INFO - Store 2422\uff5cCakes: upserted 0, mod 10
+2025-07-23 15:41:35 - INFO - Store 2422\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:41:36 - INFO - Store 2422\uff5cCakes: upserted 0, mod 11
+2025-07-23 15:41:38 - INFO - Store 2422\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:41:41 - INFO - Store 2422\uff5cCakes: upserted 0, mod 36
+2025-07-23 15:41:42 - INFO - Store 2422\uff5cCakes: upserted 0, mod 3
+2025-07-23 15:41:42 - INFO - Store 2422\uff5cCakes: upserted 0, mod 7
+2025-07-23 15:41:46 - INFO - Store 2422\uff5cCakes: upserted 0, mod 36
+2025-07-23 15:41:51 - INFO - Store 2422\uff5cCandies: upserted 0, mod 60
+2025-07-23 15:41:54 - INFO - Store 2422\uff5cCandies: upserted 0, mod 24
+2025-07-23 15:41:59 - INFO - Store 2422\uff5cCandies: upserted 0, mod 60
+2025-07-23 15:42:02 - INFO - Store 2422\uff5cDried Fruits: upserted 0, mod 36
+2025-07-23 15:42:04 - INFO - Store 2422\uff5cDried Fruits: upserted 0, mod 24
+2025-07-23 15:42:05 - INFO - Store 2422\uff5cFruit Jam: upserted 0, mod 9
+2025-07-23 15:42:07 - INFO - Store 2422\uff5cSnacks: upserted 0, mod 24
+2025-07-23 15:42:08 - INFO - Store 2403\uff5cFresh Meat: upserted 7, mod 0
+2025-07-23 15:42:08 - INFO - Store 2403\uff5cFresh Meat: upserted 2, mod 0
+2025-07-23 15:42:12 - INFO - Store 2403\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 15:42:14 - INFO - Store 2403\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 15:42:15 - INFO - Store 2403\uff5cFresh Meat: upserted 12, mod 0
+2025-07-23 15:42:20 - INFO - Store 2403\uff5cSeafood & Fish Balls: upserted 12, mod 36
+2025-07-23 15:42:22 - INFO - Store 2403\uff5cFresh Fruits: upserted 12, mod 24
+2025-07-23 15:42:25 - INFO - Store 2403\uff5cVegetables: upserted 12, mod 12
+2025-07-23 15:42:30 - INFO - Store 2403\uff5cVegetables: upserted 12, mod 36
+2025-07-23 15:42:32 - INFO - Store 2403\uff5cVegetables: upserted 12, mod 12
+2025-07-23 15:42:35 - INFO - Store 2403\uff5cVegetables: upserted 12, mod 24
+2025-07-23 15:42:40 - INFO - Store 2403\uff5cAlcoholic Beverages: upserted 12, mod 36
+2025-07-23 15:42:52 - INFO - Store 2403\uff5cAlcoholic Beverages: upserted 12, mod 120
+2025-07-23 15:42:57 - INFO - Store 2403\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:43:12 - INFO - Store 2403\uff5cBeverages: upserted 12, mod 120
+2025-07-23 15:43:24 - INFO - Store 2403\uff5cBeverages: upserted 12, mod 96
+2025-07-23 15:43:29 - INFO - Store 2403\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:43:37 - INFO - Store 2403\uff5cBeverages: upserted 12, mod 60
+2025-07-23 15:43:42 - INFO - Store 2403\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:43:43 - INFO - Store 2403\uff5cBeverages: upserted 10, mod 0
+2025-07-23 15:43:52 - INFO - Store 2403\uff5cBeverages: upserted 12, mod 72
+2025-07-23 15:44:07 - INFO - Store 2403\uff5cBeverages: upserted 12, mod 120
+2025-07-23 15:44:09 - INFO - Store 2403\uff5cBeverages: upserted 12, mod 12
+2025-07-23 15:44:13 - INFO - Store 2403\uff5cMilk: upserted 12, mod 24
+2025-07-23 15:44:20 - INFO - Store 2403\uff5cMilk: upserted 12, mod 48
+2025-07-23 15:44:23 - INFO - Store 2403\uff5cMilk: upserted 12, mod 12
+2025-07-23 15:44:27 - INFO - Store 2403\uff5cMilk: upserted 12, mod 24
+2025-07-23 15:44:45 - INFO - Store 2403\uff5cMilk: upserted 12, mod 156
+2025-07-23 15:44:50 - INFO - Store 2403\uff5cMilk: upserted 12, mod 36
+2025-07-23 15:44:51 - INFO - Store 2403\uff5cMilk: upserted 12, mod 0
+2025-07-23 15:44:52 - INFO - Store 2403\uff5cSeasonings: upserted 1, mod 0
+2025-07-23 15:44:52 - INFO - Store 2403\uff5cSeasonings: upserted 4, mod 0
+2025-07-23 15:44:58 - INFO - Store 2403\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 15:45:04 - INFO - Store 2403\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 15:45:06 - INFO - Store 2403\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:45:09 - INFO - Store 2403\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:45:13 - INFO - Store 2403\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 15:45:18 - INFO - Store 2403\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 15:45:19 - INFO - Store 2403\uff5cSeasonings: upserted 8, mod 0
+2025-07-23 15:45:21 - INFO - Store 2403\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:45:26 - INFO - Store 2403\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 15:45:27 - INFO - Store 2403\uff5cSeasonings: upserted 5, mod 0
+2025-07-23 15:45:39 - INFO - Store 2403\uff5cSeasonings: upserted 12, mod 96
+2025-07-23 15:45:41 - INFO - Store 2403\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:45:44 - INFO - Store 2403\uff5cYogurt: upserted 12, mod 24
+2025-07-23 15:45:52 - INFO - Store 2403\uff5cYogurt: upserted 12, mod 72
+2025-07-23 15:45:57 - INFO - Store 2403\uff5cYogurt: upserted 12, mod 36
+2025-07-23 15:45:59 - INFO - Store 2403\uff5cCereals & Grains: upserted 12, mod 12
+2025-07-23 15:46:01 - INFO - Store 2403\uff5cCereals & Grains: upserted 12, mod 12
+2025-07-23 15:46:04 - INFO - Store 2403\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 24
+2025-07-23 15:46:05 - INFO - Store 2403\uff5cCold Cuts: Sausages & Ham: upserted 6, mod 0
+2025-07-23 15:46:06 - INFO - Store 2403\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 15:46:09 - INFO - Store 2403\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 15:46:11 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:46:15 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 15:46:21 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:46:25 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 15:46:27 - INFO - Store 2403\uff5cInstant Foods: upserted 8, mod 0
+2025-07-23 15:46:29 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:46:31 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:46:32 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:46:37 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 15:46:40 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:46:42 - INFO - Store 2403\uff5cInstant Foods: upserted 6, mod 18
+2025-07-23 15:46:43 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:46:44 - INFO - Store 2403\uff5cInstant Foods: upserted 10, mod 0
+2025-07-23 15:46:46 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:46:47 - INFO - Store 2403\uff5cInstant Foods: upserted 7, mod 1
+2025-07-23 15:46:51 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 15:46:53 - INFO - Store 2403\uff5cInstant Foods: upserted 11, mod 13
+2025-07-23 15:46:55 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 15:46:58 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:46:58 - INFO - Store 2403\uff5cInstant Foods: upserted 1, mod 1
+2025-07-23 15:46:59 - INFO - Store 2403\uff5cInstant Foods: upserted 11, mod 1
+2025-07-23 15:47:01 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 15:47:31 - INFO - Store 2403\uff5cInstant Foods: upserted 12, mod 336
+2025-07-23 15:47:34 - INFO - Store 2403\uff5cInstant Foods: upserted 3, mod 21
+2025-07-23 15:47:39 - INFO - Store 2403\uff5cGrains & Staples: upserted 12, mod 48
+2025-07-23 15:47:42 - INFO - Store 2403\uff5cGrains & Staples: upserted 12, mod 24
+2025-07-23 15:47:53 - INFO - Store 2403\uff5cCakes: upserted 12, mod 84
+2025-07-23 15:47:58 - INFO - Store 2403\uff5cCakes: upserted 12, mod 36
+2025-07-23 15:48:01 - INFO - Store 2403\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:48:03 - INFO - Store 2403\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:48:06 - INFO - Store 2403\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:48:08 - INFO - Store 2403\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:48:11 - INFO - Store 2403\uff5cCakes: upserted 12, mod 12
+2025-07-23 15:48:11 - INFO - Store 2403\uff5cCakes: upserted 4, mod 0
+2025-07-23 15:48:12 - INFO - Store 2403\uff5cCakes: upserted 6, mod 0
+2025-07-23 15:48:17 - INFO - Store 2403\uff5cCakes: upserted 12, mod 36
+2025-07-23 15:48:22 - INFO - Store 2403\uff5cCandies: upserted 12, mod 48
+2025-07-23 15:48:23 - INFO - Store 2403\uff5cCandies: upserted 11, mod 0
+2025-07-23 15:48:30 - INFO - Store 2403\uff5cCandies: upserted 12, mod 60
+2025-07-23 15:48:33 - INFO - Store 2403\uff5cDried Fruits: upserted 12, mod 24
+2025-07-23 15:48:42 - INFO - Store 2403\uff5cDried Fruits: upserted 12, mod 24
+2025-07-23 15:48:42 - INFO - Store 2403\uff5cFruit Jam: upserted 7, mod 0
+2025-07-23 15:48:44 - INFO - Store 2403\uff5cSnacks: upserted 12, mod 12
+2025-07-23 15:48:45 - INFO - Store 2425\uff5cFresh Meat: upserted 0, mod 6
+2025-07-23 15:48:45 - INFO - Store 2425\uff5cFresh Meat: upserted 0, mod 3
+2025-07-23 15:48:48 - INFO - Store 2425\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 15:48:51 - INFO - Store 2425\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 15:48:53 - INFO - Store 2425\uff5cFresh Meat: upserted 1, mod 23
+2025-07-23 15:48:58 - INFO - Store 2425\uff5cSeafood & Fish Balls: upserted 0, mod 60
+2025-07-23 15:49:01 - INFO - Store 2425\uff5cFresh Fruits: upserted 0, mod 36
+2025-07-23 15:49:03 - INFO - Store 2425\uff5cVegetables: upserted 0, mod 24
+2025-07-23 15:49:09 - INFO - Store 2425\uff5cVegetables: upserted 0, mod 60
+2025-07-23 15:49:12 - INFO - Store 2425\uff5cVegetables: upserted 1, mod 23
+2025-07-23 15:49:15 - INFO - Store 2425\uff5cVegetables: upserted 0, mod 36
+2025-07-23 15:49:19 - INFO - Store 2425\uff5cAlcoholic Beverages: upserted 0, mod 48
+2025-07-23 15:49:32 - INFO - Store 2425\uff5cAlcoholic Beverages: upserted 0, mod 132
+2025-07-23 15:49:37 - INFO - Store 2425\uff5cBeverages: upserted 0, mod 48
+2025-07-23 15:49:52 - INFO - Store 2425\uff5cBeverages: upserted 0, mod 120
+2025-07-23 15:50:01 - INFO - Store 2425\uff5cBeverages: upserted 0, mod 96
+2025-07-23 15:50:07 - INFO - Store 2425\uff5cBeverages: upserted 0, mod 48
+2025-07-23 15:50:15 - INFO - Store 2425\uff5cBeverages: upserted 0, mod 60
+2025-07-23 15:50:20 - INFO - Store 2425\uff5cBeverages: upserted 0, mod 48
+2025-07-23 15:50:21 - INFO - Store 2425\uff5cBeverages: upserted 0, mod 9
+2025-07-23 15:50:27 - INFO - Store 2425\uff5cBeverages: upserted 0, mod 60
+2025-07-23 15:50:40 - INFO - Store 2425\uff5cBeverages: upserted 0, mod 120
+2025-07-23 15:50:42 - INFO - Store 2425\uff5cBeverages: upserted 0, mod 24
+2025-07-23 15:50:45 - INFO - Store 2425\uff5cMilk: upserted 0, mod 36
+2025-07-23 15:50:50 - INFO - Store 2425\uff5cMilk: upserted 0, mod 48
+2025-07-23 15:50:53 - INFO - Store 2425\uff5cMilk: upserted 0, mod 24
+2025-07-23 15:50:58 - INFO - Store 2425\uff5cMilk: upserted 0, mod 48
+2025-07-23 15:51:17 - INFO - Store 2425\uff5cMilk: upserted 0, mod 168
+2025-07-23 15:51:22 - INFO - Store 2425\uff5cMilk: upserted 0, mod 48
+2025-07-23 15:51:23 - INFO - Store 2425\uff5cMilk: upserted 0, mod 12
+2025-07-23 15:51:24 - INFO - Store 2425\uff5cSeasonings: upserted 0, mod 1
+2025-07-23 15:51:24 - INFO - Store 2425\uff5cSeasonings: upserted 0, mod 2
+2025-07-23 15:51:29 - INFO - Store 2425\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 15:51:35 - INFO - Store 2425\uff5cSeasonings: upserted 0, mod 60
+2025-07-23 15:51:38 - INFO - Store 2425\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:51:40 - INFO - Store 2425\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:51:44 - INFO - Store 2425\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 15:51:49 - INFO - Store 2425\uff5cSeasonings: upserted 1, mod 47
+2025-07-23 15:51:50 - INFO - Store 2425\uff5cSeasonings: upserted 0, mod 7
+2025-07-23 15:51:52 - INFO - Store 2425\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 15:51:58 - INFO - Store 2425\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 15:51:59 - INFO - Store 2425\uff5cSeasonings: upserted 0, mod 5
+2025-07-23 15:52:11 - INFO - Store 2425\uff5cSeasonings: upserted 0, mod 108
+2025-07-23 15:52:15 - INFO - Store 2425\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 15:52:18 - INFO - Store 2425\uff5cYogurt: upserted 0, mod 36
+2025-07-23 15:52:25 - INFO - Store 2425\uff5cYogurt: upserted 0, mod 72
+2025-07-23 15:52:31 - INFO - Store 2425\uff5cYogurt: upserted 0, mod 60
+2025-07-23 15:52:33 - INFO - Store 2425\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 15:52:35 - INFO - Store 2425\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 15:52:38 - INFO - Store 2425\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 36
+2025-07-23 15:52:39 - INFO - Store 2425\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 4
+2025-07-23 15:52:41 - INFO - Store 2425\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 24
+2025-07-23 15:52:43 - INFO - Store 2425\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 24
+2025-07-23 15:52:45 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:52:51 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 60
+2025-07-23 15:52:53 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:52:58 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 15:52:58 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 7
+2025-07-23 15:53:00 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:53:03 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:53:05 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:53:11 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 60
+2025-07-23 15:53:13 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:53:15 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:53:17 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:53:18 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 8
+2025-07-23 15:53:21 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:53:24 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:53:28 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 15:53:30 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:53:33 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 36
+2025-07-23 15:53:34 - INFO - Store 2425\uff5cInstant Foods: upserted 2, mod 22
+2025-07-23 15:53:35 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 2
+2025-07-23 15:53:35 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 11
+2025-07-23 15:53:38 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:54:10 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 336
+2025-07-23 15:54:15 - INFO - Store 2425\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 15:54:26 - INFO - Store 2425\uff5cGrains & Staples: upserted 0, mod 60
+2025-07-23 15:54:30 - INFO - Store 2425\uff5cGrains & Staples: upserted 0, mod 24
+2025-07-23 15:54:43 - INFO - Store 2425\uff5cCakes: upserted 0, mod 96
+2025-07-23 15:54:55 - INFO - Store 2425\uff5cCakes: upserted 0, mod 48
+2025-07-23 15:54:58 - INFO - Store 2425\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:55:00 - INFO - Store 2425\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:55:03 - INFO - Store 2425\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:55:06 - INFO - Store 2425\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:55:09 - INFO - Store 2425\uff5cCakes: upserted 0, mod 24
+2025-07-23 15:55:09 - INFO - Store 2425\uff5cCakes: upserted 0, mod 4
+2025-07-23 15:55:10 - INFO - Store 2425\uff5cCakes: upserted 0, mod 8
+2025-07-23 15:55:15 - INFO - Store 2425\uff5cCakes: upserted 0, mod 48
+2025-07-23 15:55:22 - INFO - Store 2425\uff5cCandies: upserted 0, mod 60
+2025-07-23 15:55:24 - INFO - Store 2425\uff5cCandies: upserted 0, mod 24
+2025-07-23 15:55:31 - INFO - Store 2425\uff5cCandies: upserted 0, mod 72
+2025-07-23 15:55:36 - INFO - Store 2425\uff5cDried Fruits: upserted 0, mod 48
+2025-07-23 15:55:38 - INFO - Store 2425\uff5cDried Fruits: upserted 0, mod 24
+2025-07-23 15:55:38 - INFO - Store 2425\uff5cFruit Jam: upserted 0, mod 8
+2025-07-23 15:55:41 - INFO - Store 2425\uff5cSnacks: upserted 0, mod 24
+2025-07-23 15:55:41 - INFO - Store 2717\uff5cFresh Meat: upserted 6, mod 0
+2025-07-23 15:55:42 - INFO - Store 2717\uff5cFresh Meat: upserted 2, mod 0
+2025-07-23 15:55:45 - INFO - Store 2717\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 15:55:48 - INFO - Store 2717\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 15:55:48 - INFO - Store 2717\uff5cFresh Meat: upserted 8, mod 0
+2025-07-23 15:55:51 - INFO - Store 2717\uff5cSeafood & Fish Balls: upserted 12, mod 24
+2025-07-23 15:55:54 - INFO - Store 2717\uff5cFresh Fruits: upserted 12, mod 24
+2025-07-23 15:55:56 - INFO - Store 2717\uff5cVegetables: upserted 12, mod 12
+2025-07-23 15:56:01 - INFO - Store 2717\uff5cVegetables: upserted 12, mod 36
+2025-07-23 15:56:02 - INFO - Store 2717\uff5cVegetables: upserted 7, mod 0
+2025-07-23 15:56:05 - INFO - Store 2717\uff5cVegetables: upserted 12, mod 24
+2025-07-23 15:56:10 - INFO - Store 2717\uff5cAlcoholic Beverages: upserted 12, mod 36
+2025-07-23 15:56:22 - INFO - Store 2717\uff5cAlcoholic Beverages: upserted 12, mod 120
+2025-07-23 15:56:28 - INFO - Store 2717\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:56:42 - INFO - Store 2717\uff5cBeverages: upserted 12, mod 96
+2025-07-23 15:56:53 - INFO - Store 2717\uff5cBeverages: upserted 12, mod 84
+2025-07-23 15:56:56 - INFO - Store 2717\uff5cBeverages: upserted 12, mod 24
+2025-07-23 15:57:09 - INFO - Store 2717\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:57:16 - INFO - Store 2717\uff5cBeverages: upserted 12, mod 36
+2025-07-23 15:57:17 - INFO - Store 2717\uff5cBeverages: upserted 8, mod 0
+2025-07-23 15:57:26 - INFO - Store 2717\uff5cBeverages: upserted 12, mod 60
+2025-07-23 15:57:39 - INFO - Store 2717\uff5cBeverages: upserted 12, mod 108
+2025-07-23 15:57:41 - INFO - Store 2717\uff5cBeverages: upserted 12, mod 12
+2025-07-23 15:57:45 - INFO - Store 2717\uff5cMilk: upserted 12, mod 24
+2025-07-23 15:57:52 - INFO - Store 2717\uff5cMilk: upserted 12, mod 48
+2025-07-23 15:57:54 - INFO - Store 2717\uff5cMilk: upserted 12, mod 12
+2025-07-23 15:57:58 - INFO - Store 2717\uff5cMilk: upserted 12, mod 24
+2025-07-23 15:58:40 - INFO - Store 2717\uff5cMilk: upserted 12, mod 144
+2025-07-23 15:58:45 - INFO - Store 2717\uff5cMilk: upserted 12, mod 36
+2025-07-23 15:58:45 - INFO - Store 2717\uff5cMilk: upserted 2, mod 0
+2025-07-23 15:58:46 - INFO - Store 2717\uff5cSeasonings: upserted 1, mod 0
+2025-07-23 15:58:46 - INFO - Store 2717\uff5cSeasonings: upserted 2, mod 0
+2025-07-23 15:58:50 - INFO - Store 2717\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 15:58:55 - INFO - Store 2717\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 15:58:58 - INFO - Store 2717\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:59:01 - INFO - Store 2717\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:59:05 - INFO - Store 2717\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 15:59:12 - INFO - Store 2717\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 15:59:13 - INFO - Store 2717\uff5cSeasonings: upserted 12, mod 0
+2025-07-23 15:59:16 - INFO - Store 2717\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:59:21 - INFO - Store 2717\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 15:59:22 - INFO - Store 2717\uff5cSeasonings: upserted 5, mod 0
+2025-07-23 15:59:51 - INFO - Store 2717\uff5cSeasonings: upserted 12, mod 96
+2025-07-23 15:59:53 - INFO - Store 2717\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 15:59:55 - INFO - Store 2717\uff5cYogurt: upserted 12, mod 12
+2025-07-23 16:00:03 - INFO - Store 2717\uff5cYogurt: upserted 12, mod 60
+2025-07-23 16:00:05 - INFO - Store 2717\uff5cYogurt: upserted 12, mod 12
+2025-07-23 16:00:06 - INFO - Store 2717\uff5cCereals & Grains: upserted 6, mod 0
+2025-07-23 16:00:08 - INFO - Store 2717\uff5cCereals & Grains: upserted 12, mod 12
+2025-07-23 16:00:09 - INFO - Store 2717\uff5cCold Cuts: Sausages & Ham: upserted 9, mod 0
+2025-07-23 16:00:10 - INFO - Store 2717\uff5cCold Cuts: Sausages & Ham: upserted 4, mod 0
+2025-07-23 16:00:11 - INFO - Store 2717\uff5cCold Cuts: Sausages & Ham: upserted 4, mod 0
+2025-07-23 16:00:12 - INFO - Store 2717\uff5cCold Cuts: Sausages & Ham: upserted 8, mod 0
+2025-07-23 16:00:13 - INFO - Store 2717\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:00:18 - INFO - Store 2717\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 16:00:20 - INFO - Store 2717\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:00:25 - INFO - Store 2717\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 16:00:25 - INFO - Store 2717\uff5cInstant Foods: upserted 4, mod 0
+2025-07-23 16:00:27 - INFO - Store 2717\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:00:29 - INFO - Store 2717\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:00:30 - INFO - Store 2717\uff5cInstant Foods: upserted 8, mod 0
+2025-07-23 16:00:35 - INFO - Store 2717\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 16:00:37 - INFO - Store 2717\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:00:39 - INFO - Store 2717\uff5cInstant Foods: upserted 9, mod 15
+2025-07-23 16:00:40 - INFO - Store 2717\uff5cInstant Foods: upserted 5, mod 0
+2025-07-23 16:00:40 - INFO - Store 2717\uff5cInstant Foods: upserted 1, mod 0
+2025-07-23 16:00:42 - INFO - Store 2717\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:00:42 - INFO - Store 2717\uff5cInstant Foods: upserted 4, mod 0
+2025-07-23 16:00:47 - INFO - Store 2717\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 16:00:48 - INFO - Store 2717\uff5cInstant Foods: upserted 12, mod 0
+2025-07-23 16:00:51 - INFO - Store 2717\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 16:00:51 - INFO - Store 2717\uff5cInstant Foods: upserted 7, mod 0
+2025-07-23 16:00:51 - INFO - Store 2717\uff5cInstant Foods: upserted 0, mod 1
+2025-07-23 16:00:52 - INFO - Store 2717\uff5cInstant Foods: upserted 3, mod 0
+2025-07-23 16:00:53 - INFO - Store 2717\uff5cInstant Foods: upserted 6, mod 0
+2025-07-23 16:01:21 - INFO - Store 2717\uff5cInstant Foods: upserted 12, mod 312
+2025-07-23 16:01:23 - INFO - Store 2717\uff5cInstant Foods: upserted 3, mod 2
+2025-07-23 16:01:27 - INFO - Store 2717\uff5cGrains & Staples: upserted 12, mod 36
+2025-07-23 16:01:31 - INFO - Store 2717\uff5cGrains & Staples: upserted 12, mod 24
+2025-07-23 16:01:40 - INFO - Store 2717\uff5cCakes: upserted 12, mod 60
+2025-07-23 16:01:46 - INFO - Store 2717\uff5cCakes: upserted 12, mod 36
+2025-07-23 16:01:47 - INFO - Store 2717\uff5cCakes: upserted 8, mod 0
+2025-07-23 16:01:50 - INFO - Store 2717\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:01:51 - INFO - Store 2717\uff5cCakes: upserted 11, mod 0
+2025-07-23 16:01:55 - INFO - Store 2717\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:01:57 - INFO - Store 2717\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:01:58 - INFO - Store 2717\uff5cCakes: upserted 2, mod 0
+2025-07-23 16:01:59 - INFO - Store 2717\uff5cCakes: upserted 5, mod 0
+2025-07-23 16:02:03 - INFO - Store 2717\uff5cCakes: upserted 12, mod 24
+2025-07-23 16:02:11 - INFO - Store 2717\uff5cCandies: upserted 12, mod 48
+2025-07-23 16:02:14 - INFO - Store 2717\uff5cCandies: upserted 12, mod 12
+2025-07-23 16:02:21 - INFO - Store 2717\uff5cCandies: upserted 12, mod 48
+2025-07-23 16:02:27 - INFO - Store 2717\uff5cDried Fruits: upserted 12, mod 36
+2025-07-23 16:02:31 - INFO - Store 2717\uff5cDried Fruits: upserted 12, mod 24
+2025-07-23 16:02:32 - INFO - Store 2717\uff5cFruit Jam: upserted 7, mod 0
+2025-07-23 16:02:34 - INFO - Store 2717\uff5cSnacks: upserted 12, mod 12
+2025-07-23 16:02:35 - INFO - Store 3669\uff5cFresh Meat: upserted 0, mod 7
+2025-07-23 16:02:36 - INFO - Store 3669\uff5cFresh Meat: upserted 0, mod 4
+2025-07-23 16:02:39 - INFO - Store 3669\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 16:02:43 - INFO - Store 3669\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 16:02:44 - INFO - Store 3669\uff5cFresh Meat: upserted 0, mod 11
+2025-07-23 16:02:50 - INFO - Store 3669\uff5cSeafood & Fish Balls: upserted 0, mod 48
+2025-07-23 16:02:55 - INFO - Store 3669\uff5cFresh Fruits: upserted 0, mod 48
+2025-07-23 16:02:57 - INFO - Store 3669\uff5cVegetables: upserted 0, mod 24
+2025-07-23 16:03:03 - INFO - Store 3669\uff5cVegetables: upserted 0, mod 48
+2025-07-23 16:03:06 - INFO - Store 3669\uff5cVegetables: upserted 0, mod 24
+2025-07-23 16:03:11 - INFO - Store 3669\uff5cVegetables: upserted 0, mod 36
+2025-07-23 16:03:17 - INFO - Store 3669\uff5cAlcoholic Beverages: upserted 0, mod 48
+2025-07-23 16:03:34 - INFO - Store 3669\uff5cAlcoholic Beverages: upserted 0, mod 144
+2025-07-23 16:03:40 - INFO - Store 3669\uff5cBeverages: upserted 1, mod 47
+2025-07-23 16:03:58 - INFO - Store 3669\uff5cBeverages: upserted 0, mod 132
+2025-07-23 16:04:12 - INFO - Store 3669\uff5cBeverages: upserted 0, mod 108
+2025-07-23 16:04:18 - INFO - Store 3669\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:04:28 - INFO - Store 3669\uff5cBeverages: upserted 0, mod 72
+2025-07-23 16:04:35 - INFO - Store 3669\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:04:36 - INFO - Store 3669\uff5cBeverages: upserted 0, mod 10
+2025-07-23 16:04:48 - INFO - Store 3669\uff5cBeverages: upserted 0, mod 84
+2025-07-23 16:05:05 - INFO - Store 3669\uff5cBeverages: upserted 0, mod 132
+2025-07-23 16:05:45 - INFO - Store 1935\uff5cFresh Meat: upserted 11, mod 0
+2025-07-23 16:05:45 - INFO - Store 1933\uff5cFresh Meat: upserted 9, mod 0
+2025-07-23 16:05:46 - INFO - Store 1935\uff5cFresh Meat: upserted 2, mod 0
+2025-07-23 16:05:46 - INFO - Store 2579\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 16:05:47 - INFO - Store 1933\uff5cFresh Meat: upserted 4, mod 0
+2025-07-23 16:05:47 - INFO - Store 2379\uff5cFresh Meat: upserted 0, mod 24
+2025-07-23 16:05:47 - INFO - Store 2579\uff5cFresh Meat: upserted 5, mod 0
+2025-07-23 16:05:48 - INFO - Store 2379\uff5cFresh Meat: upserted 0, mod 1
+2025-07-23 16:05:49 - INFO - Store 1935\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 16:05:49 - INFO - Store 1935\uff5cFresh Meat: upserted 6, mod 0
+2025-07-23 16:05:52 - INFO - Store 1933\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 16:05:53 - INFO - Store 2579\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 16:05:53 - INFO - Store 1933\uff5cFresh Meat: upserted 8, mod 0
+2025-07-23 16:05:54 - INFO - Store 2379\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 16:05:54 - INFO - Store 2579\uff5cFresh Meat: upserted 8, mod 0
+2025-07-23 16:05:55 - INFO - Store 2379\uff5cFresh Meat: upserted 0, mod 7
+2025-07-23 16:05:56 - INFO - Store 1935\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 16:05:57 - INFO - Store 2379\uff5cFresh Meat: upserted 0, mod 24
+2025-07-23 16:05:59 - INFO - Store 1933\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 16:06:00 - INFO - Store 2579\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 16:06:01 - INFO - Store 1935\uff5cSeafood & Fish Balls: upserted 12, mod 24
+2025-07-23 16:06:02 - INFO - Store 2379\uff5cSeafood & Fish Balls: upserted 0, mod 36
+2025-07-23 16:06:03 - INFO - Store 1933\uff5cSeafood & Fish Balls: upserted 12, mod 24
+2025-07-23 16:06:07 - INFO - Store 1935\uff5cFresh Fruits: upserted 12, mod 24
+2025-07-23 16:06:08 - INFO - Store 2379\uff5cFresh Fruits: upserted 0, mod 36
+2025-07-23 16:06:09 - INFO - Store 2579\uff5cSeafood & Fish Balls: upserted 12, mod 48
+2025-07-23 16:06:10 - INFO - Store 1933\uff5cFresh Fruits: upserted 12, mod 24
+2025-07-23 16:06:12 - INFO - Store 1935\uff5cVegetables: upserted 12, mod 24
+2025-07-23 16:06:12 - INFO - Store 2379\uff5cVegetables: upserted 0, mod 36
+2025-07-23 16:06:13 - INFO - Store 1935\uff5cVegetables: upserted 12, mod 0
+2025-07-23 16:06:16 - INFO - Store 2579\uff5cFresh Fruits: upserted 12, mod 36
+2025-07-23 16:06:16 - INFO - Store 1933\uff5cVegetables: upserted 12, mod 24
+2025-07-23 16:06:18 - INFO - Store 2379\uff5cVegetables: upserted 0, mod 24
+2025-07-23 16:06:20 - INFO - Store 1935\uff5cVegetables: upserted 12, mod 12
+2025-07-23 16:06:21 - INFO - Store 2379\uff5cVegetables: upserted 0, mod 10
+2025-07-23 16:06:21 - INFO - Store 1933\uff5cVegetables: upserted 12, mod 12
+2025-07-23 16:06:23 - INFO - Store 2579\uff5cVegetables: upserted 12, mod 24
+2025-07-23 16:06:24 - INFO - Store 1933\uff5cVegetables: upserted 10, mod 0
+2025-07-23 16:06:26 - INFO - Store 2579\uff5cVegetables: upserted 12, mod 12
+2025-07-23 16:06:28 - INFO - Store 1935\uff5cVegetables: upserted 12, mod 36
+2025-07-23 16:06:29 - INFO - Store 2379\uff5cVegetables: upserted 0, mod 48
+2025-07-23 16:06:30 - INFO - Store 2579\uff5cVegetables: upserted 12, mod 12
+2025-07-23 16:06:32 - INFO - Store 1933\uff5cVegetables: upserted 12, mod 36
+2025-07-23 16:06:37 - INFO - Store 2579\uff5cVegetables: upserted 12, mod 48
+2025-07-23 16:06:43 - INFO - Store 1935\uff5cAlcoholic Beverages: upserted 12, mod 108
+2025-07-23 16:06:46 - INFO - Store 2379\uff5cAlcoholic Beverages: upserted 0, mod 132
+2025-07-23 16:06:49 - INFO - Store 1933\uff5cAlcoholic Beverages: upserted 12, mod 108
+2025-07-23 16:06:52 - INFO - Store 1935\uff5cAlcoholic Beverages: upserted 12, mod 36
+2025-07-23 16:06:54 - INFO - Store 2379\uff5cAlcoholic Beverages: upserted 0, mod 48
+2025-07-23 16:06:55 - INFO - Store 1933\uff5cAlcoholic Beverages: upserted 12, mod 24
+2025-07-23 16:06:58 - INFO - Store 2579\uff5cAlcoholic Beverages: upserted 12, mod 120
+2025-07-23 16:07:05 - INFO - Store 2579\uff5cAlcoholic Beverages: upserted 12, mod 36
+2025-07-23 16:07:13 - INFO - Store 1935\uff5cBeverages: upserted 12, mod 120
+2025-07-23 16:07:17 - INFO - Store 2379\uff5cBeverages: upserted 0, mod 132
+2025-07-23 16:07:19 - INFO - Store 1935\uff5cBeverages: upserted 12, mod 24
+2025-07-23 16:07:20 - INFO - Store 1933\uff5cBeverages: upserted 12, mod 120
+2025-07-23 16:07:26 - INFO - Store 2579\uff5cBeverages: upserted 12, mod 108
+2025-07-23 16:07:27 - INFO - Store 2379\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:07:28 - INFO - Store 1933\uff5cBeverages: upserted 12, mod 36
+2025-07-23 16:07:31 - INFO - Store 1935\uff5cBeverages: upserted 12, mod 60
+2025-07-23 16:07:33 - INFO - Store 1935\uff5cBeverages: upserted 11, mod 0
+2025-07-23 16:07:34 - INFO - Store 2579\uff5cBeverages: upserted 12, mod 36
+2025-07-23 16:07:36 - INFO - Store 2379\uff5cBeverages: upserted 0, mod 60
+2025-07-23 16:07:38 - INFO - Store 1933\uff5cBeverages: upserted 12, mod 48
+2025-07-23 16:07:38 - INFO - Store 2379\uff5cBeverages: upserted 0, mod 12
+2025-07-23 16:07:40 - INFO - Store 1935\uff5cBeverages: upserted 12, mod 36
+2025-07-23 16:07:42 - INFO - Store 1933\uff5cBeverages: upserted 12, mod 12
+2025-07-23 16:07:44 - INFO - Store 2579\uff5cBeverages: upserted 12, mod 48
+2025-07-23 16:07:45 - INFO - Store 2379\uff5cBeverages: upserted 0, mod 36
+2025-07-23 16:07:46 - INFO - Store 1933\uff5cBeverages: upserted 12, mod 24
+2025-07-23 16:07:48 - INFO - Store 1935\uff5cBeverages: upserted 12, mod 36
+2025-07-23 16:07:48 - INFO - Store 2579\uff5cBeverages: upserted 12, mod 12
+2025-07-23 16:07:52 - INFO - Store 2379\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:07:53 - INFO - Store 1933\uff5cBeverages: upserted 12, mod 36
+2025-07-23 16:07:54 - INFO - Store 2579\uff5cBeverages: upserted 12, mod 36
+2025-07-23 16:08:01 - INFO - Store 1935\uff5cBeverages: upserted 12, mod 96
+2025-07-23 16:08:02 - INFO - Store 2579\uff5cBeverages: upserted 12, mod 36
+2025-07-23 16:08:06 - INFO - Store 2379\uff5cBeverages: upserted 0, mod 96
+2025-07-23 16:08:10 - INFO - Store 1933\uff5cBeverages: upserted 12, mod 84
+2025-07-23 16:08:17 - INFO - Store 2579\uff5cBeverages: upserted 12, mod 84
+2025-07-23 16:08:20 - INFO - Store 1935\uff5cBeverages: upserted 12, mod 132
+2025-07-23 16:08:22 - INFO - Store 1935\uff5cBeverages: upserted 8, mod 0
+2025-07-23 16:08:30 - INFO - Store 2379\uff5cBeverages: upserted 0, mod 144
+2025-07-23 16:08:31 - INFO - Store 2579\uff5cBeverages: upserted 12, mod 72
+2025-07-23 16:08:34 - INFO - Store 2379\uff5cBeverages: upserted 0, mod 9
+2025-07-23 16:08:34 - INFO - Store 2579\uff5cBeverages: upserted 9, mod 0
+2025-07-23 16:08:40 - INFO - Store 1933\uff5cBeverages: upserted 12, mod 132
+2025-07-23 16:08:40 - INFO - Store 1935\uff5cBeverages: upserted 12, mod 72
+2025-07-23 16:08:43 - INFO - Store 1933\uff5cBeverages: upserted 10, mod 0
+2025-07-23 16:08:55 - INFO - Store 2579\uff5cBeverages: upserted 12, mod 48
+2025-07-23 16:08:58 - INFO - Store 2379\uff5cBeverages: upserted 0, mod 84
+2025-07-23 16:09:01 - INFO - Store 1933\uff5cBeverages: upserted 12, mod 60
+2025-07-23 16:09:11 - INFO - Store 1935\uff5cMilk: upserted 12, mod 156
+2025-07-23 16:09:19 - INFO - Store 1935\uff5cMilk: upserted 12, mod 24
+2025-07-23 16:09:19 - INFO - Store 2579\uff5cMilk: upserted 12, mod 156
+2025-07-23 16:09:25 - INFO - Store 2579\uff5cMilk: upserted 12, mod 24
+2025-07-23 16:09:26 - INFO - Store 2379\uff5cMilk: upserted 0, mod 168
+2025-07-23 16:09:26 - INFO - Store 1935\uff5cMilk: upserted 12, mod 36
+2025-07-23 16:09:30 - INFO - Store 1935\uff5cMilk: upserted 12, mod 12
+2025-07-23 16:09:31 - INFO - Store 2579\uff5cMilk: upserted 12, mod 24
+2025-07-23 16:09:33 - INFO - Store 2379\uff5cMilk: upserted 0, mod 36
+2025-07-23 16:09:33 - INFO - Store 1933\uff5cMilk: upserted 12, mod 156
+2025-07-23 16:09:35 - INFO - Store 2579\uff5cMilk: upserted 12, mod 12
+2025-07-23 16:09:37 - INFO - Store 1935\uff5cMilk: upserted 12, mod 36
+2025-07-23 16:09:38 - INFO - Store 1935\uff5cMilk: upserted 2, mod 0
+2025-07-23 16:09:39 - INFO - Store 1933\uff5cMilk: upserted 12, mod 24
+2025-07-23 16:09:40 - INFO - Store 2379\uff5cMilk: upserted 0, mod 48
+2025-07-23 16:09:41 - INFO - Store 2579\uff5cMilk: upserted 12, mod 24
+2025-07-23 16:09:43 - INFO - Store 2379\uff5cMilk: upserted 0, mod 24
+2025-07-23 16:09:45 - INFO - Store 2579\uff5cMilk: upserted 12, mod 12
+2025-07-23 16:09:46 - INFO - Store 1933\uff5cMilk: upserted 12, mod 36
+2025-07-23 16:09:47 - INFO - Store 1935\uff5cMilk: upserted 12, mod 48
+2025-07-23 16:09:49 - INFO - Store 1935\uff5cSeasonings: upserted 9, mod 0
+2025-07-23 16:09:50 - INFO - Store 1933\uff5cMilk: upserted 12, mod 12
+2025-07-23 16:09:51 - INFO - Store 2379\uff5cMilk: upserted 0, mod 48
+2025-07-23 16:09:52 - INFO - Store 2379\uff5cMilk: upserted 0, mod 2
+2025-07-23 16:09:52 - INFO - Store 1935\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:09:55 - INFO - Store 2579\uff5cMilk: upserted 12, mod 48
+2025-07-23 16:09:57 - INFO - Store 2579\uff5cSeasonings: upserted 9, mod 0
+2025-07-23 16:09:57 - INFO - Store 1933\uff5cMilk: upserted 12, mod 36
+2025-07-23 16:10:00 - INFO - Store 1935\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 16:10:01 - INFO - Store 1935\uff5cSeasonings: upserted 1, mod 0
+2025-07-23 16:10:01 - INFO - Store 1935\uff5cSeasonings: upserted 3, mod 0
+2025-07-23 16:10:02 - INFO - Store 2579\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:10:02 - INFO - Store 2379\uff5cMilk: upserted 0, mod 60
+2025-07-23 16:10:04 - INFO - Store 2379\uff5cSeasonings: upserted 0, mod 10
+2025-07-23 16:10:05 - INFO - Store 1935\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:10:06 - INFO - Store 1933\uff5cMilk: upserted 12, mod 48
+2025-07-23 16:10:07 - INFO - Store 2379\uff5cSeasonings: upserted 1, mod 23
+2025-07-23 16:10:07 - INFO - Store 1933\uff5cSeasonings: upserted 9, mod 0
+2025-07-23 16:10:10 - INFO - Store 2579\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 16:10:10 - INFO - Store 2579\uff5cSeasonings: upserted 1, mod 0
+2025-07-23 16:10:11 - INFO - Store 1933\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:10:12 - INFO - Store 2379\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:10:12 - INFO - Store 2579\uff5cSeasonings: upserted 3, mod 0
+2025-07-23 16:10:13 - INFO - Store 2379\uff5cSeasonings: upserted 0, mod 1
+2025-07-23 16:10:13 - INFO - Store 2379\uff5cSeasonings: upserted 0, mod 3
+2025-07-23 16:10:14 - INFO - Store 1935\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 16:10:15 - INFO - Store 1933\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 16:10:16 - INFO - Store 1933\uff5cSeasonings: upserted 1, mod 0
+2025-07-23 16:10:16 - INFO - Store 2579\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:10:17 - INFO - Store 1933\uff5cSeasonings: upserted 3, mod 0
+2025-07-23 16:10:17 - INFO - Store 2379\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:10:20 - INFO - Store 1933\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:10:23 - INFO - Store 2579\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 16:10:25 - INFO - Store 2379\uff5cSeasonings: upserted 1, mod 47
+2025-07-23 16:10:27 - INFO - Store 1933\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 16:10:30 - INFO - Store 1935\uff5cSeasonings: upserted 12, mod 96
+2025-07-23 16:10:31 - INFO - Store 1935\uff5cSeasonings: upserted 5, mod 0
+2025-07-23 16:10:39 - INFO - Store 1935\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 16:10:41 - INFO - Store 2579\uff5cSeasonings: upserted 12, mod 96
+2025-07-23 16:10:42 - INFO - Store 2379\uff5cSeasonings: upserted 0, mod 96
+2025-07-23 16:10:42 - INFO - Store 2579\uff5cSeasonings: upserted 5, mod 0
+2025-07-23 16:10:43 - INFO - Store 2379\uff5cSeasonings: upserted 0, mod 4
+2025-07-23 16:10:44 - INFO - Store 1935\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:10:44 - INFO - Store 1933\uff5cSeasonings: upserted 12, mod 84
+2025-07-23 16:10:45 - INFO - Store 1933\uff5cSeasonings: upserted 4, mod 0
+2025-07-23 16:10:47 - INFO - Store 2579\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 16:10:48 - INFO - Store 2379\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:10:51 - INFO - Store 1933\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 16:10:52 - INFO - Store 2579\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:10:54 - INFO - Store 1935\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 16:10:54 - INFO - Store 2379\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:10:55 - INFO - Store 1933\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:10:59 - INFO - Store 2579\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 16:11:02 - INFO - Store 2379\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 16:11:04 - INFO - Store 1935\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 16:11:04 - INFO - Store 1933\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 16:11:06 - INFO - Store 2579\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 16:11:07 - INFO - Store 1935\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:11:08 - INFO - Store 2379\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 16:11:10 - INFO - Store 2379\uff5cSeasonings: upserted 0, mod 10
+2025-07-23 16:11:10 - INFO - Store 2579\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:11:11 - INFO - Store 2379\uff5cYogurt: upserted 0, mod 12
+2025-07-23 16:11:14 - INFO - Store 1935\uff5cYogurt: upserted 12, mod 24
+2025-07-23 16:11:14 - INFO - Store 1933\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 16:11:14 - INFO - Store 2379\uff5cYogurt: upserted 0, mod 24
+2025-07-23 16:11:17 - INFO - Store 1933\uff5cSeasonings: upserted 12, mod 0
+2025-07-23 16:11:18 - INFO - Store 2579\uff5cYogurt: upserted 12, mod 36
+2025-07-23 16:11:20 - INFO - Store 1933\uff5cYogurt: upserted 12, mod 12
+2025-07-23 16:11:22 - INFO - Store 1935\uff5cYogurt: upserted 12, mod 36
+2025-07-23 16:11:23 - INFO - Store 1933\uff5cYogurt: upserted 12, mod 12
+2025-07-23 16:11:26 - INFO - Store 2379\uff5cYogurt: upserted 0, mod 84
+2025-07-23 16:11:28 - INFO - Store 2579\uff5cYogurt: upserted 12, mod 60
+2025-07-23 16:11:28 - INFO - Store 2379\uff5cCereals & Grains: upserted 0, mod 11
+2025-07-23 16:11:31 - INFO - Store 2379\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 16:11:32 - INFO - Store 2379\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 11
+2025-07-23 16:11:33 - INFO - Store 2379\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 6
+2025-07-23 16:11:35 - INFO - Store 1935\uff5cYogurt: upserted 12, mod 72
+2025-07-23 16:11:36 - INFO - Store 1933\uff5cYogurt: upserted 12, mod 72
+2025-07-23 16:11:36 - INFO - Store 2379\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 5
+2025-07-23 16:11:37 - INFO - Store 1933\uff5cCereals & Grains: upserted 11, mod 0
+2025-07-23 16:11:37 - INFO - Store 2379\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 8
+2025-07-23 16:11:38 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 5
+2025-07-23 16:11:38 - INFO - Store 1935\uff5cCereals & Grains: upserted 12, mod 12
+2025-07-23 16:11:40 - INFO - Store 1933\uff5cCereals & Grains: upserted 9, mod 15
+2025-07-23 16:11:42 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:11:42 - INFO - Store 1933\uff5cCold Cuts: Sausages & Ham: upserted 8, mod 0
+2025-07-23 16:11:42 - INFO - Store 1935\uff5cCereals & Grains: upserted 11, mod 13
+2025-07-23 16:11:44 - INFO - Store 2579\uff5cYogurt: upserted 12, mod 72
+2025-07-23 16:11:44 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 4
+2025-07-23 16:11:44 - INFO - Store 1933\uff5cCold Cuts: Sausages & Ham: upserted 6, mod 0
+2025-07-23 16:11:45 - INFO - Store 1933\uff5cCold Cuts: Sausages & Ham: upserted 5, mod 0
+2025-07-23 16:11:46 - INFO - Store 2579\uff5cCereals & Grains: upserted 12, mod 0
+2025-07-23 16:11:46 - INFO - Store 1935\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 16:11:47 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:11:47 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 2
+2025-07-23 16:11:48 - INFO - Store 1933\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 16:11:49 - INFO - Store 1935\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 16:11:50 - INFO - Store 1933\uff5cInstant Foods: upserted 5, mod 0
+2025-07-23 16:11:50 - INFO - Store 2579\uff5cCereals & Grains: upserted 11, mod 13
+2025-07-23 16:11:50 - INFO - Store 1935\uff5cCold Cuts: Sausages & Ham: upserted 5, mod 0
+2025-07-23 16:11:51 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:11:51 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 4
+2025-07-23 16:11:52 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 6
+2025-07-23 16:11:53 - INFO - Store 1933\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:11:53 - INFO - Store 1935\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 16:11:54 - INFO - Store 1935\uff5cInstant Foods: upserted 7, mod 0
+2025-07-23 16:11:54 - INFO - Store 1933\uff5cInstant Foods: upserted 7, mod 0
+2025-07-23 16:11:56 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:11:56 - INFO - Store 2579\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 24
+2025-07-23 16:11:58 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:11:58 - INFO - Store 1933\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:11:59 - INFO - Store 1933\uff5cInstant Foods: upserted 0, mod 3
+2025-07-23 16:12:00 - INFO - Store 2579\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 12
+2025-07-23 16:12:01 - INFO - Store 2579\uff5cCold Cuts: Sausages & Ham: upserted 4, mod 0
+2025-07-23 16:12:01 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:02 - INFO - Store 1933\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:03 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 16:12:03 - INFO - Store 1933\uff5cInstant Foods: upserted 4, mod 1
+2025-07-23 16:12:04 - INFO - Store 1933\uff5cInstant Foods: upserted 7, mod 0
+2025-07-23 16:12:05 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:05 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 10
+2025-07-23 16:12:06 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 1
+2025-07-23 16:12:07 - INFO - Store 1935\uff5cInstant Foods: upserted 4, mod 7
+2025-07-23 16:12:07 - INFO - Store 2579\uff5cCold Cuts: Sausages & Ham: upserted 12, mod 24
+2025-07-23 16:12:08 - INFO - Store 1933\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:15 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:21 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:23 - INFO - Store 1935\uff5cInstant Foods: upserted 10, mod 14
+2025-07-23 16:12:24 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:24 - INFO - Store 1933\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 16:12:26 - INFO - Store 1933\uff5cInstant Foods: upserted 8, mod 1
+2025-07-23 16:12:26 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:27 - INFO - Store 1933\uff5cInstant Foods: upserted 3, mod 0
+2025-07-23 16:12:27 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:28 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:29 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:30 - INFO - Store 2579\uff5cInstant Foods: upserted 1, mod 7
+2025-07-23 16:12:32 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:34 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 16:12:35 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:37 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:38 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:38 - INFO - Store 1935\uff5cInstant Foods: upserted 2, mod 0
+2025-07-23 16:12:39 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:12:45 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 16:12:49 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 16:12:50 - INFO - Store 2579\uff5cInstant Foods: upserted 6, mod 0
+2025-07-23 16:12:51 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 336
+2025-07-23 16:12:54 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 5
+2025-07-23 16:12:58 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 36
+2025-07-23 16:13:04 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 16:13:07 - INFO - Store 1933\uff5cInstant Foods: upserted 12, mod 324
+2025-07-23 16:13:09 - INFO - Store 1933\uff5cInstant Foods: upserted 3, mod 0
+2025-07-23 16:13:10 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:13:13 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:13:14 - INFO - Store 1933\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 16:13:14 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 8
+2025-07-23 16:13:15 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 3
+2025-07-23 16:13:19 - INFO - Store 1933\uff5cInstant Foods: upserted 11, mod 37
+2025-07-23 16:13:20 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 324
+2025-07-23 16:13:22 - INFO - Store 1935\uff5cInstant Foods: upserted 7, mod 0
+2025-07-23 16:13:24 - INFO - Store 1933\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:13:24 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 36
+2025-07-23 16:13:25 - INFO - Store 1933\uff5cInstant Foods: upserted 9, mod 1
+2025-07-23 16:13:26 - INFO - Store 1933\uff5cInstant Foods: upserted 7, mod 0
+2025-07-23 16:13:27 - INFO - Store 1933\uff5cInstant Foods: upserted 3, mod 0
+2025-07-23 16:13:28 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 16:13:30 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 16:13:31 - INFO - Store 1933\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:13:34 - INFO - Store 1935\uff5cInstant Foods: upserted 11, mod 37
+2025-07-23 16:13:37 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:13:40 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 324
+2025-07-23 16:13:40 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 60
+2025-07-23 16:13:43 - INFO - Store 1933\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 16:13:43 - INFO - Store 1935\uff5cInstant Foods: upserted 8, mod 16
+2025-07-23 16:13:49 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 0
+2025-07-23 16:13:50 - INFO - Store 2379\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:13:53 - INFO - Store 1935\uff5cInstant Foods: upserted 5, mod 0
+2025-07-23 16:13:55 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:13:57 - INFO - Store 1933\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 16:13:58 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:13:59 - INFO - Store 2379\uff5cGrains & Staples: upserted 0, mod 36
+2025-07-23 16:14:01 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 16:14:01 - INFO - Store 1933\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:14:05 - INFO - Store 2379\uff5cGrains & Staples: upserted 0, mod 48
+2025-07-23 16:14:06 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 16:14:08 - INFO - Store 1933\uff5cGrains & Staples: upserted 12, mod 24
+2025-07-23 16:14:09 - INFO - Store 2579\uff5cInstant Foods: upserted 11, mod 37
+2025-07-23 16:14:10 - INFO - Store 2379\uff5cCakes: upserted 0, mod 24
+2025-07-23 16:14:11 - INFO - Store 2379\uff5cCakes: upserted 0, mod 3
+2025-07-23 16:14:12 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:14:14 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 16:14:15 - INFO - Store 2379\uff5cCakes: upserted 0, mod 24
+2025-07-23 16:14:17 - INFO - Store 1935\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:14:18 - INFO - Store 1933\uff5cGrains & Staples: upserted 12, mod 48
+2025-07-23 16:14:19 - INFO - Store 2579\uff5cInstant Foods: upserted 5, mod 31
+2025-07-23 16:14:20 - INFO - Store 2379\uff5cCakes: upserted 0, mod 24
+2025-07-23 16:14:22 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:14:22 - INFO - Store 1933\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:14:23 - INFO - Store 1935\uff5cGrains & Staples: upserted 12, mod 24
+2025-07-23 16:14:24 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:14:25 - INFO - Store 1933\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:14:27 - INFO - Store 1933\uff5cCakes: upserted 12, mod 0
+2025-07-23 16:14:28 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:14:31 - INFO - Store 1935\uff5cGrains & Staples: upserted 12, mod 48
+2025-07-23 16:14:35 - INFO - Store 2379\uff5cCakes: upserted 0, mod 96
+2025-07-23 16:14:36 - INFO - Store 2379\uff5cCakes: upserted 0, mod 4
+2025-07-23 16:14:37 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 16:14:38 - INFO - Store 1935\uff5cCakes: upserted 12, mod 24
+2025-07-23 16:14:38 - INFO - Store 1935\uff5cCakes: upserted 3, mod 0
+2025-07-23 16:14:41 - INFO - Store 1933\uff5cCakes: upserted 12, mod 72
+2025-07-23 16:14:43 - INFO - Store 1933\uff5cCakes: upserted 5, mod 0
+2025-07-23 16:14:44 - INFO - Store 2379\uff5cCakes: upserted 0, mod 48
+2025-07-23 16:14:45 - INFO - Store 1935\uff5cCakes: upserted 12, mod 24
+2025-07-23 16:14:45 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 16:14:46 - INFO - Store 2579\uff5cInstant Foods: upserted 12, mod 0
+2025-07-23 16:14:48 - INFO - Store 1935\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:14:51 - INFO - Store 2379\uff5cCakes: upserted 0, mod 48
+2025-07-23 16:14:52 - INFO - Store 1933\uff5cCakes: upserted 12, mod 36
+2025-07-23 16:14:52 - INFO - Store 2579\uff5cGrains & Staples: upserted 12, mod 24
+2025-07-23 16:14:53 - INFO - Store 2379\uff5cCakes: upserted 0, mod 12
+2025-07-23 16:14:55 - INFO - Store 2379\uff5cCakes: upserted 0, mod 24
+2025-07-23 16:15:01 - INFO - Store 2379\uff5cCandies: upserted 0, mod 24
+2025-07-23 16:15:01 - INFO - Store 1933\uff5cCakes: upserted 12, mod 36
+2025-07-23 16:15:02 - INFO - Store 1935\uff5cCakes: upserted 12, mod 72
+2025-07-23 16:15:02 - INFO - Store 2579\uff5cGrains & Staples: upserted 12, mod 48
+2025-07-23 16:15:03 - INFO - Store 1933\uff5cCakes: upserted 11, mod 0
+2025-07-23 16:15:03 - INFO - Store 1935\uff5cCakes: upserted 6, mod 0
+2025-07-23 16:15:05 - INFO - Store 2579\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:15:05 - INFO - Store 2579\uff5cCakes: upserted 3, mod 0
+2025-07-23 16:15:06 - INFO - Store 1933\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:15:10 - INFO - Store 2379\uff5cCandies: upserted 0, mod 72
+2025-07-23 16:15:11 - INFO - Store 1935\uff5cCakes: upserted 12, mod 36
+2025-07-23 16:15:12 - INFO - Store 1933\uff5cCandies: upserted 12, mod 12
+2025-07-23 16:15:12 - INFO - Store 2579\uff5cCakes: upserted 12, mod 24
+2025-07-23 16:15:15 - INFO - Store 2579\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:15:17 - INFO - Store 2379\uff5cCandies: upserted 0, mod 60
+2025-07-23 16:15:19 - INFO - Store 1935\uff5cCakes: upserted 12, mod 36
+2025-07-23 16:15:21 - INFO - Store 1935\uff5cCakes: upserted 12, mod 0
+2025-07-23 16:15:22 - INFO - Store 1933\uff5cCandies: upserted 12, mod 60
+2025-07-23 16:15:23 - INFO - Store 2379\uff5cDried Fruits: upserted 0, mod 36
+2025-07-23 16:15:24 - INFO - Store 1935\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:15:28 - INFO - Store 1935\uff5cCandies: upserted 12, mod 12
+2025-07-23 16:15:30 - INFO - Store 2379\uff5cDried Fruits: upserted 0, mod 48
+2025-07-23 16:15:30 - INFO - Store 2379\uff5cFruit Jam: upserted 0, mod 8
+2025-07-23 16:15:31 - INFO - Store 2579\uff5cCakes: upserted 12, mod 84
+2025-07-23 16:15:32 - INFO - Store 1933\uff5cCandies: upserted 12, mod 48
+2025-07-23 16:15:33 - INFO - Store 2579\uff5cCakes: upserted 9, mod 0
+2025-07-23 16:15:35 - INFO - Store 2379\uff5cSnacks: upserted 0, mod 24
+2025-07-23 16:15:35 - INFO - Store 1933\uff5cDried Fruits: upserted 12, mod 12
+2025-07-23 16:15:36 - INFO - Store 2403\uff5cFresh Meat: upserted 0, mod 12
+2025-07-23 16:15:36 - INFO - Store 2403\uff5cFresh Meat: upserted 0, mod 2
+2025-07-23 16:15:39 - INFO - Store 1935\uff5cCandies: upserted 12, mod 60
+2025-07-23 16:15:42 - INFO - Store 2403\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 16:15:42 - INFO - Store 2579\uff5cCakes: upserted 12, mod 48
+2025-07-23 16:15:43 - INFO - Store 1933\uff5cDried Fruits: upserted 12, mod 36
+2025-07-23 16:15:43 - INFO - Store 2403\uff5cFresh Meat: upserted 0, mod 7
+2025-07-23 16:15:44 - INFO - Store 1933\uff5cFruit Jam: upserted 6, mod 0
+2025-07-23 16:15:47 - INFO - Store 1935\uff5cCandies: upserted 12, mod 48
+2025-07-23 16:15:48 - INFO - Store 1933\uff5cSnacks: upserted 12, mod 12
+2025-07-23 16:15:49 - INFO - Store 2403\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 16:15:50 - INFO - Store 2715\uff5cFresh Meat: upserted 9, mod 0
+2025-07-23 16:15:50 - INFO - Store 2579\uff5cCakes: upserted 12, mod 36
+2025-07-23 16:15:50 - INFO - Store 2715\uff5cFresh Meat: upserted 3, mod 0
+2025-07-23 16:15:51 - INFO - Store 1935\uff5cDried Fruits: upserted 12, mod 12
+2025-07-23 16:15:53 - INFO - Store 2579\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:15:54 - INFO - Store 2715\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 16:15:55 - INFO - Store 2715\uff5cFresh Meat: upserted 7, mod 0
+2025-07-23 16:15:56 - INFO - Store 2403\uff5cSeafood & Fish Balls: upserted 0, mod 48
+2025-07-23 16:15:57 - INFO - Store 1935\uff5cDried Fruits: upserted 12, mod 24
+2025-07-23 16:15:58 - INFO - Store 1935\uff5cFruit Jam: upserted 7, mod 0
+2025-07-23 16:15:58 - INFO - Store 2579\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:16:00 - INFO - Store 2715\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 16:16:01 - INFO - Store 2403\uff5cFresh Fruits: upserted 0, mod 36
+2025-07-23 16:16:02 - INFO - Store 1935\uff5cSnacks: upserted 12, mod 12
+2025-07-23 16:16:02 - INFO - Store 2579\uff5cCandies: upserted 12, mod 12
+2025-07-23 16:16:05 - INFO - Store 2715\uff5cSeafood & Fish Balls: upserted 12, mod 24
+2025-07-23 16:16:07 - INFO - Store 2436\uff5cFresh Meat: upserted 0, mod 24
+2025-07-23 16:16:07 - INFO - Store 2403\uff5cVegetables: upserted 0, mod 36
+2025-07-23 16:16:08 - INFO - Store 2436\uff5cFresh Meat: upserted 0, mod 2
+2025-07-23 16:16:13 - INFO - Store 2715\uff5cFresh Fruits: upserted 12, mod 24
+2025-07-23 16:16:13 - INFO - Store 2403\uff5cVegetables: upserted 0, mod 24
+2025-07-23 16:16:13 - INFO - Store 2436\uff5cFresh Meat: upserted 4, mod 20
+2025-07-23 16:16:14 - INFO - Store 2436\uff5cFresh Meat: upserted 0, mod 7
+2025-07-23 16:16:15 - INFO - Store 2403\uff5cVegetables: upserted 0, mod 24
+2025-07-23 16:16:17 - INFO - Store 2579\uff5cCandies: upserted 12, mod 60
+2025-07-23 16:16:19 - INFO - Store 2715\uff5cVegetables: upserted 12, mod 24
+2025-07-23 16:16:20 - INFO - Store 2436\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 16:16:22 - INFO - Store 2403\uff5cVegetables: upserted 0, mod 48
+2025-07-23 16:16:23 - INFO - Store 2715\uff5cVegetables: upserted 12, mod 12
+2025-07-23 16:16:24 - INFO - Store 2715\uff5cVegetables: upserted 7, mod 0
+2025-07-23 16:16:25 - INFO - Store 2579\uff5cCandies: upserted 12, mod 48
+2025-07-23 16:16:26 - INFO - Store 2436\uff5cSeafood & Fish Balls: upserted 0, mod 36
+2025-07-23 16:16:28 - INFO - Store 2579\uff5cDried Fruits: upserted 12, mod 12
+2025-07-23 16:16:29 - INFO - Store 2715\uff5cVegetables: upserted 12, mod 36
+2025-07-23 16:16:31 - INFO - Store 2436\uff5cFresh Fruits: upserted 0, mod 36
+2025-07-23 16:16:34 - INFO - Store 2579\uff5cDried Fruits: upserted 12, mod 36
+2025-07-23 16:16:36 - INFO - Store 2579\uff5cFruit Jam: upserted 9, mod 0
+2025-07-23 16:16:36 - INFO - Store 2436\uff5cVegetables: upserted 4, mod 32
+2025-07-23 16:16:38 - INFO - Store 2436\uff5cVegetables: upserted 0, mod 10
+2025-07-23 16:16:40 - INFO - Store 2403\uff5cAlcoholic Beverages: upserted 0, mod 132
+2025-07-23 16:16:41 - INFO - Store 2579\uff5cSnacks: upserted 12, mod 12
+2025-07-23 16:16:43 - INFO - Store 2422\uff5cFresh Meat: upserted 0, mod 11
+2025-07-23 16:16:43 - INFO - Store 2436\uff5cVegetables: upserted 1, mod 23
+2025-07-23 16:16:47 - INFO - Store 2715\uff5cAlcoholic Beverages: upserted 12, mod 96
+2025-07-23 16:16:48 - INFO - Store 2403\uff5cAlcoholic Beverages: upserted 0, mod 48
+2025-07-23 16:16:49 - INFO - Store 2422\uff5cFresh Meat: upserted 0, mod 24
+2025-07-23 16:16:50 - INFO - Store 2422\uff5cFresh Meat: upserted 0, mod 8
+2025-07-23 16:16:51 - INFO - Store 2436\uff5cVegetables: upserted 0, mod 48
+2025-07-23 16:16:52 - INFO - Store 2715\uff5cAlcoholic Beverages: upserted 12, mod 24
+2025-07-23 16:16:53 - INFO - Store 2422\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 16:16:58 - INFO - Store 2422\uff5cSeafood & Fish Balls: upserted 3, mod 45
+2025-07-23 16:17:04 - INFO - Store 2422\uff5cFresh Fruits: upserted 0, mod 36
+2025-07-23 16:17:08 - INFO - Store 2403\uff5cBeverages: upserted 0, mod 132
+2025-07-23 16:17:09 - INFO - Store 2422\uff5cVegetables: upserted 1, mod 35
+2025-07-23 16:17:09 - INFO - Store 2715\uff5cBeverages: upserted 12, mod 84
+2025-07-23 16:17:13 - INFO - Store 2436\uff5cAlcoholic Beverages: upserted 0, mod 132
+2025-07-23 16:17:14 - INFO - Store 2422\uff5cVegetables: upserted 0, mod 24
+2025-07-23 16:17:18 - INFO - Store 2715\uff5cBeverages: upserted 12, mod 24
+2025-07-23 16:17:19 - INFO - Store 2403\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:17:20 - INFO - Store 2422\uff5cVegetables: upserted 0, mod 24
+2025-07-23 16:17:22 - INFO - Store 2436\uff5cAlcoholic Beverages: upserted 0, mod 48
+2025-07-23 16:17:25 - INFO - Store 2422\uff5cVegetables: upserted 0, mod 48
+2025-07-23 16:17:28 - INFO - Store 2715\uff5cBeverages: upserted 12, mod 48
+2025-07-23 16:17:29 - INFO - Store 2715\uff5cBeverages: upserted 7, mod 0
+2025-07-23 16:17:30 - INFO - Store 2403\uff5cBeverages: upserted 0, mod 72
+2025-07-23 16:17:33 - INFO - Store 2715\uff5cBeverages: upserted 12, mod 24
+2025-07-23 16:17:34 - INFO - Store 2403\uff5cBeverages: upserted 0, mod 24
+2025-07-23 16:17:42 - INFO - Store 2436\uff5cBeverages: upserted 0, mod 132
+2025-07-23 16:17:43 - INFO - Store 2715\uff5cBeverages: upserted 12, mod 36
+2025-07-23 16:17:43 - INFO - Store 2403\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:17:45 - INFO - Store 2422\uff5cAlcoholic Beverages: upserted 0, mod 132
+2025-07-23 16:17:49 - INFO - Store 2436\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:17:51 - INFO - Store 2403\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:17:52 - INFO - Store 2422\uff5cAlcoholic Beverages: upserted 0, mod 48
+2025-07-23 16:17:55 - INFO - Store 2715\uff5cBeverages: upserted 12, mod 60
+2025-07-23 16:17:58 - INFO - Store 2436\uff5cBeverages: upserted 0, mod 72
+2025-07-23 16:18:01 - INFO - Store 2436\uff5cBeverages: upserted 1, mod 23
+2025-07-23 16:18:07 - INFO - Store 2403\uff5cBeverages: upserted 0, mod 108
+2025-07-23 16:18:09 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 108
+2025-07-23 16:18:10 - INFO - Store 2436\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:18:16 - INFO - Store 2715\uff5cBeverages: upserted 12, mod 96
+2025-07-23 16:18:17 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:18:18 - INFO - Store 2715\uff5cBeverages: upserted 11, mod 0
+2025-07-23 16:18:18 - INFO - Store 2436\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:18:24 - INFO - Store 2403\uff5cBeverages: upserted 0, mod 132
+2025-07-23 16:18:26 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 60
+2025-07-23 16:18:27 - INFO - Store 2403\uff5cBeverages: upserted 0, mod 10
+2025-07-23 16:18:28 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 11
+2025-07-23 16:18:29 - INFO - Store 2715\uff5cBeverages: upserted 12, mod 48
+2025-07-23 16:18:36 - INFO - Store 2436\uff5cBeverages: upserted 1, mod 107
+2025-07-23 16:18:36 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:18:40 - INFO - Store 2403\uff5cBeverages: upserted 0, mod 84
+2025-07-23 16:18:43 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:18:49 - INFO - Store 2715\uff5cMilk: upserted 12, mod 144
+2025-07-23 16:18:52 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 60
+2025-07-23 16:18:56 - INFO - Store 2715\uff5cMilk: upserted 12, mod 12
+2025-07-23 16:18:58 - INFO - Store 2436\uff5cBeverages: upserted 0, mod 144
+2025-07-23 16:19:00 - INFO - Store 2436\uff5cBeverages: upserted 0, mod 10
+2025-07-23 16:19:02 - INFO - Store 2715\uff5cMilk: upserted 12, mod 24
+2025-07-23 16:19:06 - INFO - Store 2715\uff5cMilk: upserted 12, mod 12
+2025-07-23 16:19:10 - INFO - Store 2403\uff5cMilk: upserted 0, mod 168
+2025-07-23 16:19:14 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 120
+2025-07-23 16:19:16 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 8
+2025-07-23 16:19:16 - INFO - Store 2436\uff5cBeverages: upserted 0, mod 84
+2025-07-23 16:19:16 - INFO - Store 2715\uff5cMilk: upserted 12, mod 24
+2025-07-23 16:19:17 - INFO - Store 2715\uff5cMilk: upserted 2, mod 0
+2025-07-23 16:19:19 - INFO - Store 2403\uff5cMilk: upserted 0, mod 36
+2025-07-23 16:19:23 - INFO - Store 2422\uff5cBeverages: upserted 0, mod 60
+2025-07-23 16:19:26 - INFO - Store 2715\uff5cMilk: upserted 12, mod 36
+2025-07-23 16:19:26 - INFO - Store 2403\uff5cMilk: upserted 0, mod 36
+2025-07-23 16:19:27 - INFO - Store 2715\uff5cSeasonings: upserted 9, mod 0
+2025-07-23 16:19:28 - INFO - Store 2715\uff5cSeasonings: upserted 12, mod 0
+2025-07-23 16:19:29 - INFO - Store 2403\uff5cMilk: upserted 0, mod 24
+2025-07-23 16:19:33 - INFO - Store 2715\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 16:19:34 - INFO - Store 2715\uff5cSeasonings: upserted 1, mod 0
+2025-07-23 16:19:34 - INFO - Store 2715\uff5cSeasonings: upserted 3, mod 0
+2025-07-23 16:19:36 - INFO - Store 2403\uff5cMilk: upserted 0, mod 48
+2025-07-23 16:19:39 - INFO - Store 2403\uff5cMilk: upserted 0, mod 12
+2025-07-23 16:19:41 - INFO - Store 2715\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:19:44 - INFO - Store 2436\uff5cMilk: upserted 1, mod 167
+2025-07-23 16:19:47 - INFO - Store 2422\uff5cMilk: upserted 0, mod 156
+2025-07-23 16:19:49 - INFO - Store 2715\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 16:19:52 - INFO - Store 2403\uff5cMilk: upserted 0, mod 60
+2025-07-23 16:19:52 - INFO - Store 2436\uff5cMilk: upserted 0, mod 36
+2025-07-23 16:19:52 - INFO - Store 2422\uff5cMilk: upserted 0, mod 24
+2025-07-23 16:19:53 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 8
+2025-07-23 16:19:57 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:19:58 - INFO - Store 2422\uff5cMilk: upserted 0, mod 36
+2025-07-23 16:20:00 - INFO - Store 2436\uff5cMilk: upserted 0, mod 36
+2025-07-23 16:20:02 - INFO - Store 2422\uff5cMilk: upserted 0, mod 24
+2025-07-23 16:20:03 - INFO - Store 2715\uff5cSeasonings: upserted 12, mod 72
+2025-07-23 16:20:03 - INFO - Store 2436\uff5cMilk: upserted 0, mod 24
+2025-07-23 16:20:04 - INFO - Store 2715\uff5cSeasonings: upserted 5, mod 0
+2025-07-23 16:20:05 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 16:20:06 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 1
+2025-07-23 16:20:06 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 4
+2025-07-23 16:20:10 - INFO - Store 2422\uff5cMilk: upserted 0, mod 48
+2025-07-23 16:20:11 - INFO - Store 2422\uff5cMilk: upserted 0, mod 4
+2025-07-23 16:20:12 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:20:13 - INFO - Store 2436\uff5cMilk: upserted 0, mod 48
+2025-07-23 16:20:13 - INFO - Store 2715\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 16:20:14 - INFO - Store 2436\uff5cMilk: upserted 0, mod 7
+2025-07-23 16:20:16 - INFO - Store 2715\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:20:19 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 16:20:20 - INFO - Store 2422\uff5cMilk: upserted 0, mod 60
+2025-07-23 16:20:20 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 7
+2025-07-23 16:20:23 - INFO - Store 2436\uff5cMilk: upserted 0, mod 60
+2025-07-23 16:20:24 - INFO - Store 2715\uff5cSeasonings: upserted 11, mod 33
+2025-07-23 16:20:25 - INFO - Store 2436\uff5cSeasonings: upserted 1, mod 9
+2025-07-23 16:20:25 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:20:28 - INFO - Store 2436\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:20:32 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:20:32 - INFO - Store 2715\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 16:20:33 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 1
+2025-07-23 16:20:33 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 1
+2025-07-23 16:20:34 - INFO - Store 2715\uff5cSeasonings: upserted 8, mod 0
+2025-07-23 16:20:35 - INFO - Store 2715\uff5cYogurt: upserted 8, mod 0
+2025-07-23 16:20:36 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 108
+2025-07-23 16:20:36 - INFO - Store 2436\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:20:36 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:20:36 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 5
+2025-07-23 16:20:37 - INFO - Store 2436\uff5cSeasonings: upserted 0, mod 1
+2025-07-23 16:20:37 - INFO - Store 2715\uff5cYogurt: upserted 12, mod 12
+2025-07-23 16:20:38 - INFO - Store 2436\uff5cSeasonings: upserted 0, mod 3
+2025-07-23 16:20:40 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:20:42 - INFO - Store 2436\uff5cSeasonings: upserted 1, mod 23
+2025-07-23 16:20:44 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:20:45 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 16:20:46 - INFO - Store 2715\uff5cYogurt: upserted 12, mod 48
+2025-07-23 16:20:47 - INFO - Store 2715\uff5cCereals & Grains: upserted 7, mod 0
+2025-07-23 16:20:48 - INFO - Store 2436\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 16:20:49 - INFO - Store 2715\uff5cCereals & Grains: upserted 11, mod 13
+2025-07-23 16:20:50 - INFO - Store 2715\uff5cCold Cuts: Sausages & Ham: upserted 8, mod 0
+2025-07-23 16:20:51 - INFO - Store 2715\uff5cCold Cuts: Sausages & Ham: upserted 5, mod 0
+2025-07-23 16:20:52 - INFO - Store 2715\uff5cCold Cuts: Sausages & Ham: upserted 3, mod 0
+2025-07-23 16:20:53 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 60
+2025-07-23 16:20:53 - INFO - Store 2715\uff5cCold Cuts: Sausages & Ham: upserted 9, mod 0
+2025-07-23 16:20:53 - INFO - Store 2715\uff5cInstant Foods: upserted 3, mod 0
+2025-07-23 16:20:56 - INFO - Store 2715\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:20:58 - INFO - Store 2715\uff5cInstant Foods: upserted 5, mod 0
+2025-07-23 16:20:59 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 96
+2025-07-23 16:21:01 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 4
+2025-07-23 16:21:01 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 16:21:03 - INFO - Store 2715\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:21:04 - INFO - Store 2715\uff5cInstant Foods: upserted 0, mod 3
+2025-07-23 16:21:04 - INFO - Store 2436\uff5cSeasonings: upserted 0, mod 96
+2025-07-23 16:21:05 - INFO - Store 2403\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:21:06 - INFO - Store 2436\uff5cSeasonings: upserted 0, mod 4
+2025-07-23 16:21:07 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:21:07 - INFO - Store 2715\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:21:08 - INFO - Store 2715\uff5cInstant Foods: upserted 3, mod 0
+2025-07-23 16:21:08 - INFO - Store 2715\uff5cInstant Foods: upserted 3, mod 0
+2025-07-23 16:21:09 - INFO - Store 2403\uff5cYogurt: upserted 0, mod 36
+2025-07-23 16:21:11 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:21:11 - INFO - Store 2715\uff5cInstant Foods: upserted 11, mod 0
+2025-07-23 16:21:13 - INFO - Store 2436\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:21:15 - INFO - Store 2403\uff5cYogurt: upserted 0, mod 48
+2025-07-23 16:21:17 - INFO - Store 2436\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:21:18 - INFO - Store 2715\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 16:21:18 - INFO - Store 2715\uff5cInstant Foods: upserted 9, mod 1
+2025-07-23 16:21:19 - INFO - Store 2715\uff5cInstant Foods: upserted 2, mod 0
+2025-07-23 16:21:21 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 60
+2025-07-23 16:21:23 - INFO - Store 2436\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 16:21:25 - INFO - Store 2403\uff5cYogurt: upserted 0, mod 84
+2025-07-23 16:21:29 - INFO - Store 2403\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 16:21:29 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 60
+2025-07-23 16:21:32 - INFO - Store 2403\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 16:21:32 - INFO - Store 2422\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:21:34 - INFO - Store 2436\uff5cSeasonings: upserted 0, mod 72
+2025-07-23 16:21:36 - INFO - Store 2403\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 36
+2025-07-23 16:21:37 - INFO - Store 2422\uff5cYogurt: upserted 0, mod 36
+2025-07-23 16:21:39 - INFO - Store 2436\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:21:41 - INFO - Store 2403\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 24
+2025-07-23 16:21:44 - INFO - Store 2403\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 6
+2025-07-23 16:21:48 - INFO - Store 2436\uff5cYogurt: upserted 0, mod 36
+2025-07-23 16:21:48 - INFO - Store 2403\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 24
+2025-07-23 16:21:49 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 12
+2025-07-23 16:21:51 - INFO - Store 2422\uff5cYogurt: upserted 0, mod 48
+2025-07-23 16:21:51 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:21:58 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:21:58 - INFO - Store 2436\uff5cYogurt: upserted 0, mod 48
+2025-07-23 16:22:03 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:22:05 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 10
+2025-07-23 16:22:09 - INFO - Store 2422\uff5cYogurt: upserted 0, mod 72
+2025-07-23 16:22:12 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:22:16 - INFO - Store 2422\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 16:22:19 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:22:25 - INFO - Store 2436\uff5cYogurt: upserted 0, mod 84
+2025-07-23 16:22:25 - INFO - Store 2422\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 16:22:27 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:22:31 - INFO - Store 2436\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 16:22:33 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:22:34 - INFO - Store 2422\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 24
+2025-07-23 16:22:36 - INFO - Store 2422\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 10
+2025-07-23 16:22:38 - INFO - Store 2422\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 3
+2025-07-23 16:22:38 - INFO - Store 2436\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 16:22:44 - INFO - Store 2422\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 24
+2025-07-23 16:22:45 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 16:22:47 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 5
+2025-07-23 16:22:50 - INFO - Store 2436\uff5cCold Cuts: Sausages & Ham: upserted 1, mod 35
+2025-07-23 16:22:52 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:22:54 - INFO - Store 2715\uff5cInstant Foods: upserted 12, mod 300
+2025-07-23 16:22:54 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:22:56 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 2
+2025-07-23 16:22:56 - INFO - Store 2715\uff5cInstant Foods: upserted 6, mod 0
+2025-07-23 16:22:56 - INFO - Store 2436\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 11
+2025-07-23 16:22:57 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 11
+2025-07-23 16:22:57 - INFO - Store 2436\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 5
+2025-07-23 16:22:58 - INFO - Store 2715\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:23:00 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:23:00 - INFO - Store 2436\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 24
+2025-07-23 16:23:01 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 6
+2025-07-23 16:23:01 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 10
+2025-07-23 16:23:03 - INFO - Store 2715\uff5cInstant Foods: upserted 12, mod 24
+2025-07-23 16:23:04 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:23:04 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:23:06 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 12
+2025-07-23 16:23:06 - INFO - Store 2715\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:23:07 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 6
+2025-07-23 16:23:07 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:23:09 - INFO - Store 2715\uff5cInstant Foods: upserted 7, mod 4
+2025-07-23 16:23:09 - INFO - Store 2715\uff5cInstant Foods: upserted 5, mod 0
+2025-07-23 16:23:10 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:23:10 - INFO - Store 2715\uff5cInstant Foods: upserted 3, mod 0
+2025-07-23 16:23:10 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:23:11 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 8
+2025-07-23 16:23:13 - INFO - Store 2715\uff5cInstant Foods: upserted 12, mod 12
+2025-07-23 16:23:14 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:23:16 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 16:23:17 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:23:20 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:23:21 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 2
+2025-07-23 16:23:21 - INFO - Store 2715\uff5cInstant Foods: upserted 12, mod 36
+2025-07-23 16:23:22 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:23:25 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:23:28 - INFO - Store 2715\uff5cInstant Foods: upserted 12, mod 48
+2025-07-23 16:23:29 - INFO - Store 2715\uff5cInstant Foods: upserted 11, mod 0
+2025-07-23 16:23:31 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 16:23:32 - INFO - Store 2715\uff5cGrains & Staples: upserted 12, mod 12
+2025-07-23 16:23:34 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:23:38 - INFO - Store 2715\uff5cGrains & Staples: upserted 12, mod 36
+2025-07-23 16:23:39 - INFO - Store 2715\uff5cCakes: upserted 12, mod 0
+2025-07-23 16:23:40 - INFO - Store 2715\uff5cCakes: upserted 1, mod 0
+2025-07-23 16:23:41 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 348
+2025-07-23 16:23:44 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 8
+2025-07-23 16:23:46 - INFO - Store 2715\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:23:47 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 36
+2025-07-23 16:23:50 - INFO - Store 2715\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:23:53 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 16:23:59 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:24:07 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:24:12 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:24:13 - INFO - Store 2715\uff5cCakes: upserted 12, mod 60
+2025-07-23 16:24:13 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 8
+2025-07-23 16:24:14 - INFO - Store 2715\uff5cCakes: upserted 3, mod 0
+2025-07-23 16:24:15 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 324
+2025-07-23 16:24:19 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:24:20 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:24:23 - INFO - Store 2715\uff5cCakes: upserted 12, mod 36
+2025-07-23 16:24:26 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 36
+2025-07-23 16:24:28 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 60
+2025-07-23 16:24:30 - INFO - Store 2715\uff5cCakes: upserted 12, mod 24
+2025-07-23 16:24:31 - INFO - Store 2715\uff5cCakes: upserted 10, mod 0
+2025-07-23 16:24:32 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 16:24:34 - INFO - Store 2715\uff5cCakes: upserted 12, mod 12
+2025-07-23 16:24:37 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 348
+2025-07-23 16:24:37 - INFO - Store 2715\uff5cCandies: upserted 11, mod 0
+2025-07-23 16:24:39 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:24:39 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 12
+2025-07-23 16:24:40 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 60
+2025-07-23 16:24:42 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:24:43 - INFO - Store 2403\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:24:45 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 36
+2025-07-23 16:24:46 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:24:46 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 3
+2025-07-23 16:24:48 - INFO - Store 2715\uff5cCandies: upserted 12, mod 48
+2025-07-23 16:24:49 - INFO - Store 2403\uff5cGrains & Staples: upserted 0, mod 36
+2025-07-23 16:24:50 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:24:52 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 16:24:56 - INFO - Store 2715\uff5cCandies: upserted 12, mod 36
+2025-07-23 16:24:56 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:24:57 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 48
+2025-07-23 16:24:59 - INFO - Store 2436\uff5cInstant Foods: upserted 1, mod 23
+2025-07-23 16:25:00 - INFO - Store 2403\uff5cGrains & Staples: upserted 0, mod 60
+2025-07-23 16:25:01 - INFO - Store 2715\uff5cDried Fruits: upserted 12, mod 12
+2025-07-23 16:25:02 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:25:03 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 6
+2025-07-23 16:25:04 - INFO - Store 2403\uff5cCakes: upserted 0, mod 24
+2025-07-23 16:25:05 - INFO - Store 2403\uff5cCakes: upserted 0, mod 4
+2025-07-23 16:25:06 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 60
+2025-07-23 16:25:07 - INFO - Store 2715\uff5cDried Fruits: upserted 12, mod 24
+2025-07-23 16:25:08 - INFO - Store 2422\uff5cInstant Foods: upserted 0, mod 10
+2025-07-23 16:25:09 - INFO - Store 2715\uff5cFruit Jam: upserted 8, mod 0
+2025-07-23 16:25:09 - INFO - Store 2403\uff5cCakes: upserted 0, mod 24
+2025-07-23 16:25:10 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 36
+2025-07-23 16:25:12 - INFO - Store 2715\uff5cSnacks: upserted 12, mod 12
+2025-07-23 16:25:13 - INFO - Store 2403\uff5cCakes: upserted 0, mod 24
+2025-07-23 16:25:14 - INFO - Store 2422\uff5cGrains & Staples: upserted 0, mod 36
+2025-07-23 16:25:15 - INFO - Store 2736\uff5cFresh Meat: upserted 0, mod 24
+2025-07-23 16:25:16 - INFO - Store 2736\uff5cFresh Meat: upserted 0, mod 3
+2025-07-23 16:25:18 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 60
+2025-07-23 16:25:20 - INFO - Store 2422\uff5cGrains & Staples: upserted 0, mod 48
+2025-07-23 16:25:21 - INFO - Store 2736\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 16:25:23 - INFO - Store 2736\uff5cFresh Meat: upserted 0, mod 8
+2025-07-23 16:25:24 - INFO - Store 2422\uff5cCakes: upserted 0, mod 24
+2025-07-23 16:25:25 - INFO - Store 2422\uff5cCakes: upserted 0, mod 3
+2025-07-23 16:25:26 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 60
+2025-07-23 16:25:29 - INFO - Store 2736\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 16:25:30 - INFO - Store 2436\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:25:31 - INFO - Store 2403\uff5cCakes: upserted 0, mod 96
+2025-07-23 16:25:31 - INFO - Store 2403\uff5cCakes: upserted 0, mod 6
+2025-07-23 16:25:32 - INFO - Store 2422\uff5cCakes: upserted 0, mod 36
+2025-07-23 16:25:33 - INFO - Store 2422\uff5cCakes: upserted 0, mod 11
+2025-07-23 16:25:34 - INFO - Store 2436\uff5cGrains & Staples: upserted 0, mod 36
+2025-07-23 16:25:37 - INFO - Store 2736\uff5cSeafood & Fish Balls: upserted 2, mod 58
+2025-07-23 16:25:39 - INFO - Store 2403\uff5cCakes: upserted 0, mod 48
+2025-07-23 16:25:41 - INFO - Store 2436\uff5cGrains & Staples: upserted 0, mod 48
+2025-07-23 16:25:45 - INFO - Store 2736\uff5cFresh Fruits: upserted 0, mod 48
+2025-07-23 16:25:46 - INFO - Store 2422\uff5cCakes: upserted 0, mod 84
+2025-07-23 16:25:48 - INFO - Store 2422\uff5cCakes: upserted 0, mod 7
+2025-07-23 16:25:48 - INFO - Store 2403\uff5cCakes: upserted 0, mod 48
+2025-07-23 16:25:49 - INFO - Store 2436\uff5cCakes: upserted 0, mod 36
+2025-07-23 16:25:50 - INFO - Store 2736\uff5cVegetables: upserted 3, mod 33
+2025-07-23 16:25:50 - INFO - Store 2436\uff5cCakes: upserted 0, mod 4
+2025-07-23 16:25:52 - INFO - Store 2403\uff5cCakes: upserted 0, mod 24
+2025-07-23 16:25:53 - INFO - Store 2736\uff5cVegetables: upserted 2, mod 22
+2025-07-23 16:25:56 - INFO - Store 2422\uff5cCakes: upserted 0, mod 48
+2025-07-23 16:25:56 - INFO - Store 2403\uff5cCakes: upserted 0, mod 24
+2025-07-23 16:25:57 - INFO - Store 2436\uff5cCakes: upserted 0, mod 36
+2025-07-23 16:25:57 - INFO - Store 2736\uff5cVegetables: upserted 0, mod 24
+2025-07-23 16:25:57 - INFO - Store 2403\uff5cCandies: upserted 0, mod 11
+2025-07-23 16:26:00 - INFO - Store 2436\uff5cCakes: upserted 1, mod 23
+2025-07-23 16:26:00 - INFO - Store 2422\uff5cCakes: upserted 0, mod 36
+2025-07-23 16:26:01 - INFO - Store 2422\uff5cCakes: upserted 0, mod 10
+2025-07-23 16:26:05 - INFO - Store 2736\uff5cVegetables: upserted 0, mod 60
+2025-07-23 16:26:05 - INFO - Store 2422\uff5cCakes: upserted 0, mod 24
+2025-07-23 16:26:07 - INFO - Store 2403\uff5cCandies: upserted 0, mod 72
+2025-07-23 16:26:09 - INFO - Store 2422\uff5cCandies: upserted 0, mod 24
+2025-07-23 16:26:14 - INFO - Store 2436\uff5cCakes: upserted 0, mod 96
+2025-07-23 16:26:14 - INFO - Store 2403\uff5cCandies: upserted 0, mod 60
+2025-07-23 16:26:15 - INFO - Store 2436\uff5cCakes: upserted 0, mod 5
+2025-07-23 16:26:18 - INFO - Store 2422\uff5cCandies: upserted 0, mod 60
+2025-07-23 16:26:20 - INFO - Store 2403\uff5cDried Fruits: upserted 0, mod 36
+2025-07-23 16:26:24 - INFO - Store 2436\uff5cCakes: upserted 0, mod 60
+2025-07-23 16:26:24 - INFO - Store 2403\uff5cDried Fruits: upserted 0, mod 36
+2025-07-23 16:26:26 - INFO - Store 2403\uff5cFruit Jam: upserted 0, mod 7
+2025-07-23 16:26:26 - INFO - Store 2736\uff5cAlcoholic Beverages: upserted 0, mod 132
+2025-07-23 16:26:29 - INFO - Store 2422\uff5cCandies: upserted 0, mod 60
+2025-07-23 16:26:31 - INFO - Store 2436\uff5cCakes: upserted 0, mod 48
+2025-07-23 16:26:33 - INFO - Store 2422\uff5cDried Fruits: upserted 0, mod 24
+2025-07-23 16:26:33 - INFO - Store 2736\uff5cAlcoholic Beverages: upserted 0, mod 48
+2025-07-23 16:26:34 - INFO - Store 2436\uff5cCakes: upserted 0, mod 8
+2025-07-23 16:26:35 - INFO - Store 2403\uff5cSnacks: upserted 0, mod 24
+2025-07-23 16:26:36 - INFO - Store 4244\uff5cFresh Meat: upserted 1, mod 11
+2025-07-23 16:26:37 - INFO - Store 2436\uff5cCakes: upserted 0, mod 24
+2025-07-23 16:26:37 - INFO - Store 2422\uff5cDried Fruits: upserted 0, mod 36
+2025-07-23 16:26:38 - INFO - Store 4244\uff5cFresh Meat: upserted 0, mod 5
+2025-07-23 16:26:38 - INFO - Store 2422\uff5cFruit Jam: upserted 0, mod 9
+2025-07-23 16:26:41 - INFO - Store 2436\uff5cCandies: upserted 1, mod 23
+2025-07-23 16:26:41 - INFO - Store 4244\uff5cFresh Meat: upserted 0, mod 24
+2025-07-23 16:26:42 - INFO - Store 4244\uff5cFresh Meat: upserted 0, mod 6
+2025-07-23 16:26:43 - INFO - Store 2422\uff5cSnacks: upserted 0, mod 24
+2025-07-23 16:26:45 - INFO - Store 2792\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 16:26:46 - INFO - Store 2792\uff5cFresh Meat: upserted 3, mod 0
+2025-07-23 16:26:49 - INFO - Store 4244\uff5cFresh Meat: upserted 0, mod 36
+2025-07-23 16:26:50 - INFO - Store 2792\uff5cFresh Meat: upserted 12, mod 12
+2025-07-23 16:26:50 - INFO - Store 2736\uff5cBeverages: upserted 0, mod 108
+2025-07-23 16:26:50 - INFO - Store 2792\uff5cFresh Meat: upserted 5, mod 0
+2025-07-23 16:26:52 - INFO - Store 2436\uff5cCandies: upserted 0, mod 72
+2025-07-23 16:26:55 - INFO - Store 2792\uff5cFresh Meat: upserted 12, mod 24
+2025-07-23 16:26:55 - INFO - Store 4244\uff5cSeafood & Fish Balls: upserted 1, mod 47
+2025-07-23 16:26:58 - INFO - Store 2736\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:26:59 - INFO - Store 2792\uff5cSeafood & Fish Balls: upserted 12, mod 24
+2025-07-23 16:27:01 - INFO - Store 4244\uff5cFresh Fruits: upserted 0, mod 36
+2025-07-23 16:27:02 - INFO - Store 2436\uff5cCandies: upserted 0, mod 60
+2025-07-23 16:27:05 - INFO - Store 4244\uff5cVegetables: upserted 0, mod 36
+2025-07-23 16:27:07 - INFO - Store 2792\uff5cFresh Fruits: upserted 12, mod 36
+2025-07-23 16:27:09 - INFO - Store 2736\uff5cBeverages: upserted 0, mod 60
+2025-07-23 16:27:09 - INFO - Store 4244\uff5cVegetables: upserted 0, mod 24
+2025-07-23 16:27:09 - INFO - Store 2436\uff5cDried Fruits: upserted 0, mod 36
+2025-07-23 16:27:12 - INFO - Store 2792\uff5cVegetables: upserted 12, mod 24
+2025-07-23 16:27:13 - INFO - Store 4244\uff5cVegetables: upserted 0, mod 24
+2025-07-23 16:27:13 - INFO - Store 2736\uff5cBeverages: upserted 0, mod 24
+2025-07-23 16:27:16 - INFO - Store 2436\uff5cDried Fruits: upserted 0, mod 48
+2025-07-23 16:27:16 - INFO - Store 2792\uff5cVegetables: upserted 12, mod 12
+2025-07-23 16:27:18 - INFO - Store 2436\uff5cFruit Jam: upserted 0, mod 9
+2025-07-23 16:27:18 - INFO - Store 2792\uff5cVegetables: upserted 10, mod 0
+2025-07-23 16:27:20 - INFO - Store 2736\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:27:21 - INFO - Store 4244\uff5cVegetables: upserted 0, mod 48
+2025-07-23 16:27:21 - INFO - Store 2436\uff5cSnacks: upserted 0, mod 24
+2025-07-23 16:27:22 - INFO - Store 2477\uff5cFresh Meat: upserted 0, mod 9
+2025-07-23 16:27:23 - INFO - Store 2477\uff5cFresh Meat: upserted 0, mod 1
+2025-07-23 16:27:25 - INFO - Store 2792\uff5cVegetables: upserted 12, mod 36
+2025-07-23 16:27:27 - INFO - Store 2477\uff5cFresh Meat: upserted 0, mod 24
+2025-07-23 16:27:28 - INFO - Store 2477\uff5cFresh Meat: upserted 0, mod 8
+2025-07-23 16:27:28 - INFO - Store 2736\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:27:30 - INFO - Store 2477\uff5cFresh Meat: upserted 0, mod 24
+2025-07-23 16:27:35 - INFO - Store 2477\uff5cSeafood & Fish Balls: upserted 0, mod 36
+2025-07-23 16:27:40 - INFO - Store 2477\uff5cFresh Fruits: upserted 0, mod 24
+2025-07-23 16:27:40 - INFO - Store 4244\uff5cAlcoholic Beverages: upserted 0, mod 156
+2025-07-23 16:27:44 - INFO - Store 2792\uff5cAlcoholic Beverages: upserted 12, mod 108
+2025-07-23 16:27:46 - INFO - Store 2477\uff5cVegetables: upserted 3, mod 21
+2025-07-23 16:27:48 - INFO - Store 2477\uff5cVegetables: upserted 0, mod 12
+2025-07-23 16:27:49 - INFO - Store 2736\uff5cBeverages: upserted 0, mod 96
+2025-07-23 16:27:49 - INFO - Store 4244\uff5cAlcoholic Beverages: upserted 0, mod 48
+2025-07-23 16:27:50 - INFO - Store 2792\uff5cAlcoholic Beverages: upserted 12, mod 24
+2025-07-23 16:27:51 - INFO - Store 2477\uff5cVegetables: upserted 0, mod 8
+2025-07-23 16:27:54 - INFO - Store 2477\uff5cVegetables: upserted 0, mod 36
+2025-07-23 16:28:04 - INFO - Store 2736\uff5cBeverages: upserted 0, mod 120
+2025-07-23 16:28:06 - INFO - Store 2736\uff5cBeverages: upserted 0, mod 10
+2025-07-23 16:28:15 - INFO - Store 2477\uff5cAlcoholic Beverages: upserted 0, mod 120
+2025-07-23 16:28:15 - INFO - Store 2792\uff5cBeverages: upserted 12, mod 120
+2025-07-23 16:28:16 - INFO - Store 4244\uff5cBeverages: upserted 0, mod 144
+2025-07-23 16:28:17 - INFO - Store 2736\uff5cBeverages: upserted 0, mod 60
+2025-07-23 16:28:20 - INFO - Store 2477\uff5cAlcoholic Beverages: upserted 0, mod 36
+2025-07-23 16:28:23 - INFO - Store 4244\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:28:24 - INFO - Store 2792\uff5cBeverages: upserted 12, mod 36
+2025-07-23 16:28:34 - INFO - Store 4244\uff5cBeverages: upserted 0, mod 72
+2025-07-23 16:28:35 - INFO - Store 2792\uff5cBeverages: upserted 12, mod 48
+2025-07-23 16:28:38 - INFO - Store 2792\uff5cBeverages: upserted 11, mod 0
+2025-07-23 16:28:39 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 120
+2025-07-23 16:28:40 - INFO - Store 4244\uff5cBeverages: upserted 0, mod 24
+2025-07-23 16:28:43 - INFO - Store 2792\uff5cBeverages: upserted 12, mod 24
+2025-07-23 16:28:43 - INFO - Store 2736\uff5cMilk: upserted 0, mod 168
+2025-07-23 16:28:46 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 48
+2025-07-23 16:28:46 - INFO - Store 2736\uff5cMilk: upserted 0, mod 24
+2025-07-23 16:28:49 - INFO - Store 4244\uff5cBeverages: upserted 0, mod 60
+2025-07-23 16:28:51 - INFO - Store 2792\uff5cBeverages: upserted 12, mod 36
+2025-07-23 16:28:52 - INFO - Store 2736\uff5cMilk: upserted 0, mod 36
+2025-07-23 16:28:53 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 36
+2025-07-23 16:28:55 - INFO - Store 2736\uff5cMilk: upserted 0, mod 24
+2025-07-23 16:28:56 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 24
+2025-07-23 16:28:59 - INFO - Store 4244\uff5cBeverages: upserted 0, mod 60
+2025-07-23 16:29:02 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 36
+2025-07-23 16:29:03 - INFO - Store 2736\uff5cMilk: upserted 0, mod 48
+2025-07-23 16:29:08 - INFO - Store 2736\uff5cMilk: upserted 0, mod 24
+2025-07-23 16:29:09 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 36
+2025-07-23 16:29:10 - INFO - Store 2792\uff5cBeverages: upserted 12, mod 96
+2025-07-23 16:29:18 - INFO - Store 4244\uff5cBeverages: upserted 1, mod 107
+2025-07-23 16:29:18 - INFO - Store 2736\uff5cMilk: upserted 0, mod 60
+2025-07-23 16:29:21 - INFO - Store 2736\uff5cSeasonings: upserted 1, mod 9
+2025-07-23 16:29:22 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 84
+2025-07-23 16:29:24 - INFO - Store 2736\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:29:30 - INFO - Store 2792\uff5cBeverages: upserted 12, mod 120
+2025-07-23 16:29:32 - INFO - Store 2792\uff5cBeverages: upserted 8, mod 0
+2025-07-23 16:29:32 - INFO - Store 2736\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 16:29:33 - INFO - Store 2736\uff5cSeasonings: upserted 0, mod 1
+2025-07-23 16:29:33 - INFO - Store 2736\uff5cSeasonings: upserted 0, mod 3
+2025-07-23 16:29:38 - INFO - Store 2736\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:29:41 - INFO - Store 4244\uff5cBeverages: upserted 0, mod 144
+2025-07-23 16:29:43 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 120
+2025-07-23 16:29:44 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 9
+2025-07-23 16:29:45 - INFO - Store 2792\uff5cBeverages: upserted 12, mod 72
+2025-07-23 16:29:46 - INFO - Store 4244\uff5cBeverages: upserted 0, mod 24
+2025-07-23 16:29:47 - INFO - Store 2736\uff5cSeasonings: upserted 1, mod 47
+2025-07-23 16:29:53 - INFO - Store 2477\uff5cBeverages: upserted 0, mod 60
+2025-07-23 16:30:00 - INFO - Store 4244\uff5cBeverages: upserted 0, mod 96
+2025-07-23 16:30:03 - INFO - Store 2736\uff5cSeasonings: upserted 0, mod 108
+2025-07-23 16:30:03 - INFO - Store 2736\uff5cSeasonings: upserted 0, mod 4
+2025-07-23 16:30:09 - INFO - Store 2792\uff5cMilk: upserted 12, mod 156
+2025-07-23 16:30:10 - INFO - Store 2736\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:30:16 - INFO - Store 2736\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:30:18 - INFO - Store 2792\uff5cMilk: upserted 12, mod 24
+2025-07-23 16:30:19 - INFO - Store 2477\uff5cMilk: upserted 0, mod 156
+2025-07-23 16:30:24 - INFO - Store 2477\uff5cMilk: upserted 0, mod 24
+2025-07-23 16:30:25 - INFO - Store 2792\uff5cMilk: upserted 12, mod 24
+2025-07-23 16:30:27 - INFO - Store 4244\uff5cMilk: upserted 0, mod 168
+2025-07-23 16:30:28 - INFO - Store 2736\uff5cSeasonings: upserted 0, mod 60
+2025-07-23 16:30:30 - INFO - Store 2792\uff5cMilk: upserted 12, mod 12
+2025-07-23 16:30:30 - INFO - Store 2477\uff5cMilk: upserted 0, mod 36
+2025-07-23 16:30:32 - INFO - Store 4244\uff5cMilk: upserted 0, mod 36
+2025-07-23 16:30:34 - INFO - Store 2477\uff5cMilk: upserted 0, mod 24
+2025-07-23 16:30:35 - INFO - Store 2736\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 16:30:38 - INFO - Store 2792\uff5cMilk: upserted 12, mod 36
+2025-07-23 16:30:39 - INFO - Store 2736\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:30:40 - INFO - Store 2792\uff5cMilk: upserted 2, mod 0
+2025-07-23 16:30:41 - INFO - Store 4244\uff5cMilk: upserted 0, mod 48
+2025-07-23 16:30:42 - INFO - Store 2477\uff5cMilk: upserted 0, mod 48
+2025-07-23 16:30:43 - INFO - Store 2477\uff5cMilk: upserted 0, mod 1
+2025-07-23 16:30:44 - INFO - Store 4244\uff5cMilk: upserted 0, mod 24
+2025-07-23 16:30:45 - INFO - Store 2736\uff5cYogurt: upserted 1, mod 47
+2025-07-23 16:30:49 - INFO - Store 2792\uff5cMilk: upserted 12, mod 48
+2025-07-23 16:30:51 - INFO - Store 2477\uff5cMilk: upserted 0, mod 48
+2025-07-23 16:30:51 - INFO - Store 2792\uff5cSeasonings: upserted 10, mod 0
+2025-07-23 16:30:52 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 9
+2025-07-23 16:30:53 - INFO - Store 4244\uff5cMilk: upserted 0, mod 48
+2025-07-23 16:30:54 - INFO - Store 4244\uff5cMilk: upserted 0, mod 8
+2025-07-23 16:30:55 - INFO - Store 2792\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:30:56 - INFO - Store 2736\uff5cYogurt: upserted 0, mod 72
+2025-07-23 16:30:57 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:30:59 - INFO - Store 2792\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 16:31:00 - INFO - Store 2792\uff5cSeasonings: upserted 1, mod 0
+2025-07-23 16:31:01 - INFO - Store 2792\uff5cSeasonings: upserted 2, mod 0
+2025-07-23 16:31:02 - INFO - Store 4244\uff5cMilk: upserted 0, mod 60
+2025-07-23 16:31:03 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:31:04 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 1
+2025-07-23 16:31:04 - INFO - Store 4244\uff5cSeasonings: upserted 0, mod 9
+2025-07-23 16:31:05 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 2
+2025-07-23 16:31:05 - INFO - Store 2792\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:31:06 - INFO - Store 4244\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:31:08 - INFO - Store 2736\uff5cYogurt: upserted 0, mod 84
+2025-07-23 16:31:09 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:31:12 - INFO - Store 2736\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 16:31:13 - INFO - Store 4244\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:31:14 - INFO - Store 4244\uff5cSeasonings: upserted 0, mod 2
+2025-07-23 16:31:14 - INFO - Store 4244\uff5cSeasonings: upserted 0, mod 3
+2025-07-23 16:31:16 - INFO - Store 2792\uff5cSeasonings: upserted 12, mod 36
+2025-07-23 16:31:16 - INFO - Store 2736\uff5cCereals & Grains: upserted 0, mod 24
+2025-07-23 16:31:17 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:31:18 - INFO - Store 4244\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:31:20 - INFO - Store 2736\uff5cCold Cuts: Sausages & Ham: upserted 1, mod 35
+2025-07-23 16:31:23 - INFO - Store 2736\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 24
+2025-07-23 16:31:25 - INFO - Store 2736\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 4
+2025-07-23 16:31:26 - INFO - Store 4244\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 16:31:31 - INFO - Store 2736\uff5cCold Cuts: Sausages & Ham: upserted 0, mod 36
+2025-07-23 16:31:33 - INFO - Store 2792\uff5cSeasonings: upserted 12, mod 96
+2025-07-23 16:31:33 - INFO - Store 2792\uff5cSeasonings: upserted 4, mod 0
+2025-07-23 16:31:34 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 96
+2025-07-23 16:31:35 - INFO - Store 2736\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:31:35 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 5
+2025-07-23 16:31:38 - INFO - Store 2736\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:31:39 - INFO - Store 2792\uff5cSeasonings: upserted 12, mod 24
+2025-07-23 16:31:42 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:31:43 - INFO - Store 2736\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:31:45 - INFO - Store 2792\uff5cSeasonings: upserted 12, mod 12
+2025-07-23 16:31:45 - INFO - Store 4244\uff5cSeasonings: upserted 0, mod 120
+2025-07-23 16:31:45 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 24
+2025-07-23 16:31:46 - INFO - Store 4244\uff5cSeasonings: upserted 0, mod 5
+2025-07-23 16:31:47 - INFO - Store 2736\uff5cInstant Foods: upserted 0, mod 24
+2025-07-23 16:31:47 - INFO - Store 2736\uff5cInstant Foods: upserted 0, mod 8
+2025-07-23 16:31:51 - INFO - Store 2736\uff5cInstant Foods: upserted 0, mod 22
+2025-07-23 16:31:51 - INFO - Store 4244\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:31:53 - INFO - Store 2477\uff5cSeasonings: upserted 0, mod 48
+2025-07-23 16:31:54 - INFO - Store 2792\uff5cSeasonings: upserted 12, mod 48
+2025-07-23 16:31:55 - INFO - Store 2736\uff5cInstant Foods: upserted 1, mod 23
+2025-07-23 16:31:56 - INFO - Store 4244\uff5cSeasonings: upserted 0, mod 36
+2025-07-23 16:31:58 - INFO - Store 2736\uff5cInstant Foods: upserted 0, mod 24

--- a/crawler/bhx/demo.py
+++ b/crawler/bhx/demo.py
@@ -139,8 +139,8 @@ class BHXDataFetcher:
                 logger.error(f"Unexpected error: {e}")
         
 
-async def main():
-    fetcher = BHXDataFetcher(concurrency=1)
+async def main(concurrency: int = 4):
+    fetcher = BHXDataFetcher(concurrency=concurrency)
     await fetcher.init()
     start = None
     end = None
@@ -160,7 +160,7 @@ async def main():
                                         fetcher.token, fetcher.deviceid)
         
         # test thử 1 store
-        stores = stores[56:57]
+        stores = stores[77:100]
 
         # 3. Crawl productá
         start = time.time()
@@ -174,8 +174,8 @@ async def main():
     finally:
         await fetcher.close()
 
-def run_sync():
+def run_sync(concurrency: int = 4):
     if sys.platform.startswith("win"):
         asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 
-    asyncio.run(main())
+    asyncio.run(main(concurrency))

--- a/crawler/winmart/demo.py
+++ b/crawler/winmart/demo.py
@@ -102,13 +102,13 @@ class WinMartFetcher:
         elapsed = time.time() - start_time
         logger.info(f"✅ Total time: {elapsed:.2f} seconds")
 
-async def main():
-    fetcher = WinMartFetcher(concurrency=3)
+async def main(concurrency: int = 3):
+    fetcher = WinMartFetcher(concurrency)
     await fetcher.init()
     await fetcher.run()
 
-def run_sync():
+def run_sync(concurrency: int = 3):
     if sys.platform.startswith("win"):
         asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 
-    asyncio.run(main())
+    asyncio.run(main(concurrency))

--- a/run.py
+++ b/run.py
@@ -3,4 +3,4 @@ from crawler.bhx.demo import run_sync
 # from crawler.winmart.demo import run_sync
 
 if __name__ == "__main__":
-    run_sync()
+    run_sync(concurrency=1)


### PR DESCRIPTION
## Summary by Sourcery

Parameterize concurrency settings for BHX and WinMart crawler demos, adjust the BHX store selection range, and clean up the default script invocation in run.py.

New Features:
- Make concurrency configurable in BHX crawler demo by adding a concurrency parameter to main and run_sync
- Make concurrency configurable in WinMart crawler demo by adding a concurrency parameter to main and run_sync

Enhancements:
- Update BHX demo to crawl a different subset of stores (indices 77-100)

Chores:
- Remove the default run_sync() invocation from the top-level run.py entrypoint